### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/acronym/.meta/tests.toml
+++ b/exercises/acronym/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# basic
+"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+
+# lowercase words
+"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+
+# punctuation
+"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+
+# all caps word
+"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+
+# punctuation without whitespace
+"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+
+# very long abbreviation
+"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+
+# consecutive delimiters
+"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+
+# apostrophes
+"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+
+# underscore emphasis
+"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true

--- a/exercises/all-your-base/.meta/tests.toml
+++ b/exercises/all-your-base/.meta/tests.toml
@@ -1,0 +1,64 @@
+[canonical-tests]
+
+# single bit one to decimal
+"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+
+# binary to single decimal
+"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+
+# single decimal to binary
+"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+
+# binary to multiple decimal
+"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+
+# decimal to binary
+"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+
+# trinary to hexadecimal
+"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+
+# hexadecimal to trinary
+"d3901c80-8190-41b9-bd86-38d988efa956" = true
+
+# 15-bit integer
+"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+
+# empty list
+"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+
+# single zero
+"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+
+# multiple zeros
+"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+
+# leading zeros
+"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+
+# input base is one
+"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+
+# input base is zero
+"e21a693a-7a69-450b-b393-27415c26a016" = true
+
+# input base is negative
+"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+
+# negative digit
+"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+
+# invalid positive digit
+"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+
+# output base is one
+"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+
+# output base is zero
+"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+
+# output base is negative
+"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+
+# both bases are negative
+"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true

--- a/exercises/allergies/.meta/tests.toml
+++ b/exercises/allergies/.meta/tests.toml
@@ -1,0 +1,148 @@
+[canonical-tests]
+
+# not allergic to anything
+"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+
+# allergic only to eggs
+"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+
+# allergic to eggs and something else
+"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+
+# allergic to something, but not eggs
+"64a6a83a-5723-4b5b-a896-663307403310" = true
+
+# allergic to everything
+"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+
+# not allergic to anything
+"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+
+# allergic only to peanuts
+"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+
+# allergic to peanuts and something else
+"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+
+# allergic to something, but not peanuts
+"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+
+# allergic to everything
+"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+
+# not allergic to anything
+"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+
+# allergic only to shellfish
+"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+
+# allergic to shellfish and something else
+"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+
+# allergic to something, but not shellfish
+"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+
+# allergic to everything
+"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+
+# not allergic to anything
+"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+
+# allergic only to strawberries
+"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+
+# allergic to strawberries and something else
+"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+
+# allergic to something, but not strawberries
+"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+
+# allergic to everything
+"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+
+# not allergic to anything
+"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+
+# allergic only to tomatoes
+"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+
+# allergic to tomatoes and something else
+"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+
+# allergic to something, but not tomatoes
+"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+
+# allergic to everything
+"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+
+# not allergic to anything
+"978467ab-bda4-49f7-b004-1d011ead947c" = true
+
+# allergic only to chocolate
+"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+
+# allergic to chocolate and something else
+"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+
+# allergic to something, but not chocolate
+"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+
+# allergic to everything
+"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+
+# not allergic to anything
+"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+
+# allergic only to pollen
+"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+
+# allergic to pollen and something else
+"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+
+# allergic to something, but not pollen
+"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+
+# allergic to everything
+"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+
+# not allergic to anything
+"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+
+# allergic only to cats
+"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+
+# allergic to cats and something else
+"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+
+# allergic to something, but not cats
+"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+
+# allergic to everything
+"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+
+# no allergies
+"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+
+# just eggs
+"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+
+# just peanuts
+"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+
+# just strawberries
+"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+
+# eggs and peanuts
+"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+
+# more than eggs but not peanuts
+"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+
+# lots of stuff
+"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+
+# everything
+"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+
+# no allergen score parts
+"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true

--- a/exercises/anagram/.meta/tests.toml
+++ b/exercises/anagram/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# no matches
+"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+
+# detects two anagrams
+"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+
+# does not detect anagram subsets
+"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+
+# detects anagram
+"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+
+# detects three anagrams
+"99c91beb-838f-4ccd-b123-935139917283" = true
+
+# detects multiple anagrams with different case
+"78487770-e258-4e1f-a646-8ece10950d90" = true
+
+# does not detect non-anagrams with identical checksum
+"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+
+# detects anagrams case-insensitively
+"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+
+# detects anagrams using case-insensitive subject
+"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+
+# detects anagrams using case-insensitive possible matches
+"f367325c-78ec-411c-be76-e79047f4bd54" = true
+
+# does not detect an anagram if the original word is repeated
+"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+
+# anagrams must use all letters exactly once
+"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+
+# words are not anagrams of themselves (case-insensitive)
+"85757361-4535-45fd-ac0e-3810d40debc1" = true
+
+# words other than themselves can be anagrams
+"a0705568-628c-4b55-9798-82e4acde51ca" = true

--- a/exercises/atbash-cipher/.meta/tests.toml
+++ b/exercises/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,43 @@
+[canonical-tests]
+
+# encode yes
+"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+
+# encode no
+"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+
+# encode OMG
+"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+
+# encode spaces
+"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+
+# encode mindblowingly
+"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+
+# encode numbers
+"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+
+# encode deep thought
+"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+
+# encode all the letters
+"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+
+# decode exercism
+"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+
+# decode a sentence
+"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+
+# decode numbers
+"18729de3-de74-49b8-b68c-025eaf77f851" = true
+
+# decode all the letters
+"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+
+# decode with too many spaces
+"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+
+# decode with no spaces
+"b34edf13-34c0-49b5-aa21-0768928000d5" = true

--- a/exercises/binary/.meta/tests.toml
+++ b/exercises/binary/.meta/tests.toml
@@ -1,0 +1,46 @@
+[canonical-tests]
+
+# binary 0 is decimal 0
+"567fc71e-1013-4915-9285-bca0648c0844" = true
+
+# binary 1 is decimal 1
+"c0824fb1-6a0a-4e9a-a262-c6c00af99fa8" = true
+
+# binary 10 is decimal 2
+"4d2834fb-3cc3-4159-a8fd-da1098def8ed" = true
+
+# binary 11 is decimal 3
+"b7b2b649-4a7c-4808-9eb9-caf00529bac6" = true
+
+# binary 100 is decimal 4
+"de761aff-73cd-43c1-9e1f-0417f07b1e4a" = true
+
+# binary 1001 is decimal 9
+"7849a8f7-f4a1-4966-963e-503282d6814c" = true
+
+# binary 11010 is decimal 26
+"836a101c-aecb-473b-ba78-962408dcda98" = true
+
+# binary 10001101000 is decimal 1128
+"1c6822a4-8584-438b-8dd4-40f0f0b66371" = true
+
+# binary ignores leading zeros
+"91ffe632-8374-4016-b1d1-d8400d9f940d" = true
+
+# 2 is not a valid binary digit
+"44f7d8b1-ddc3-4751-8be3-700a538b421c" = true
+
+# a number containing a non-binary digit is invalid
+"c263a24d-6870-420f-b783-628feefd7b6e" = true
+
+# a number with trailing non-binary characters is invalid
+"8d81305b-0502-4a07-bfba-051c5526d7f2" = true
+
+# a number with leading non-binary characters is invalid
+"a7f79b6b-039a-4d42-99b4-fcee56679f03" = true
+
+# a number with internal non-binary characters is invalid
+"9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e" = true
+
+# a number and a word whitespace separated is invalid
+"46c8dd65-0c32-4273-bb0d-f2b111bccfbd" = true

--- a/exercises/bob/.meta/tests.toml
+++ b/exercises/bob/.meta/tests.toml
@@ -1,0 +1,76 @@
+[canonical-tests]
+
+# stating something
+"e162fead-606f-437a-a166-d051915cea8e" = true
+
+# shouting
+"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+
+# shouting gibberish
+"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+
+# asking a question
+"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+
+# asking a numeric question
+"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+
+# asking gibberish
+"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+
+# talking forcefully
+"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+
+# using acronyms in regular speech
+"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+
+# forceful question
+"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+
+# shouting numbers
+"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+
+# no letters
+"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+
+# question with no letters
+"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+
+# shouting with special characters
+"496143c8-1c31-4c01-8a08-88427af85c66" = true
+
+# shouting with no exclamation mark
+"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+
+# statement containing question mark
+"aa8097cc-c548-4951-8856-14a404dd236a" = true
+
+# non-letters with question
+"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+
+# prattling on
+"8608c508-f7de-4b17-985b-811878b3cf45" = true
+
+# silence
+"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+
+# prolonged silence
+"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+
+# alternate silence
+"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+
+# multiple line question
+"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+
+# starting with whitespace
+"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+
+# ending with whitespace
+"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+
+# other whitespace
+"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+
+# non-question ending with whitespace
+"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true

--- a/exercises/clock/.meta/tests.toml
+++ b/exercises/clock/.meta/tests.toml
@@ -1,0 +1,157 @@
+[canonical-tests]
+
+# on the hour
+"a577bacc-106b-496e-9792-b3083ea8705e" = true
+
+# past the hour
+"b5d0c360-3b88-489b-8e84-68a1c7a4fa23" = true
+
+# midnight is zero hours
+"473223f4-65f3-46ff-a9f7-7663c7e59440" = true
+
+# hour rolls over
+"ca95d24a-5924-447d-9a96-b91c8334725c" = true
+
+# hour rolls over continuously
+"f3826de0-0925-4d69-8ac8-89aea7e52b78" = true
+
+# sixty minutes is next hour
+"a02f7edf-dfd4-4b11-b21a-86de3cc6a95c" = true
+
+# minutes roll over
+"8f520df6-b816-444d-b90f-8a477789beb5" = true
+
+# minutes roll over continuously
+"c75c091b-47ac-4655-8d40-643767fc4eed" = true
+
+# hour and minutes roll over
+"06343ecb-cf39-419d-a3f5-dcbae0cc4c57" = true
+
+# hour and minutes roll over continuously
+"be60810e-f5d9-4b58-9351-a9d1e90e660c" = true
+
+# hour and minutes roll over to exactly midnight
+"1689107b-0b5c-4bea-aad3-65ec9859368a" = true
+
+# negative hour
+"d3088ee8-91b7-4446-9e9d-5e2ad6219d91" = true
+
+# negative hour rolls over
+"77ef6921-f120-4d29-bade-80d54aa43b54" = true
+
+# negative hour rolls over continuously
+"359294b5-972f-4546-bb9a-a85559065234" = true
+
+# negative minutes
+"509db8b7-ac19-47cc-bd3a-a9d2f30b03c0" = true
+
+# negative minutes roll over
+"5d6bb225-130f-4084-84fd-9e0df8996f2a" = true
+
+# negative minutes roll over continuously
+"d483ceef-b520-4f0c-b94a-8d2d58cf0484" = true
+
+# negative sixty minutes is previous hour
+"1cd19447-19c6-44bf-9d04-9f8305ccb9ea" = true
+
+# negative hour and minutes both roll over
+"9d3053aa-4f47-4afc-bd45-d67a72cef4dc" = true
+
+# negative hour and minutes both roll over continuously
+"51d41fcf-491e-4ca0-9cae-2aa4f0163ad4" = true
+
+# add minutes
+"d098e723-ad29-4ef9-997a-2693c4c9d89a" = true
+
+# add no minutes
+"b6ec8f38-e53e-4b22-92a7-60dab1f485f4" = true
+
+# add to next hour
+"efd349dd-0785-453e-9ff8-d7452a8e7269" = true
+
+# add more than one hour
+"749890f7-aba9-4702-acce-87becf4ef9fe" = true
+
+# add more than two hours with carry
+"da63e4c1-1584-46e3-8d18-c9dc802c1713" = true
+
+# add across midnight
+"be167a32-3d33-4cec-a8bc-accd47ddbb71" = true
+
+# add more than one day (1500 min = 25 hrs)
+"6672541e-cdae-46e4-8be7-a820cc3be2a8" = true
+
+# add more than two days
+"1918050d-c79b-4cb7-b707-b607e2745c7e" = true
+
+# subtract minutes
+"37336cac-5ede-43a5-9026-d426cbe40354" = true
+
+# subtract to previous hour
+"0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b" = true
+
+# subtract more than an hour
+"9b4e809c-612f-4b15-aae0-1df0acb801b9" = true
+
+# subtract across midnight
+"8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6" = true
+
+# subtract more than two hours
+"07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9" = true
+
+# subtract more than two hours with borrow
+"90ac8a1b-761c-4342-9c9c-cdc3ed5db097" = true
+
+# subtract more than one day (1500 min = 25 hrs)
+"2149f985-7136-44ad-9b29-ec023a97a2b7" = true
+
+# subtract more than two days
+"ba11dbf0-ac27-4acb-ada9-3b853ec08c97" = true
+
+# clocks with same time
+"f2fdad51-499f-4c9b-a791-b28c9282e311" = true
+
+# clocks a minute apart
+"5d409d4b-f862-4960-901e-ec430160b768" = true
+
+# clocks an hour apart
+"a6045fcf-2b52-4a47-8bb2-ef10a064cba5" = true
+
+# clocks with hour overflow
+"66b12758-0be5-448b-a13c-6a44bce83527" = true
+
+# clocks with hour overflow by several days
+"2b19960c-212e-4a71-9aac-c581592f8111" = true
+
+# clocks with negative hour
+"6f8c6541-afac-4a92-b0c2-b10d4e50269f" = true
+
+# clocks with negative hour that wraps
+"bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d" = true
+
+# clocks with negative hour that wraps multiple times
+"56c0326d-565b-4d19-a26f-63b3205778b7" = true
+
+# clocks with minute overflow
+"c90b9de8-ddff-4ffe-9858-da44a40fdbc2" = true
+
+# clocks with minute overflow by several days
+"533a3dc5-59a7-491b-b728-a7a34fe325de" = true
+
+# clocks with negative minute
+"fff49e15-f7b7-4692-a204-0f6052d62636" = true
+
+# clocks with negative minute that wraps
+"605c65bb-21bd-43eb-8f04-878edf508366" = true
+
+# clocks with negative minute that wraps multiple times
+"b87e64ed-212a-4335-91fd-56da8421d077" = true
+
+# clocks with negative hours and minutes
+"822fbf26-1f3b-4b13-b9bf-c914816b53dd" = true
+
+# clocks with negative hours and minutes that wrap
+"e787bccd-cf58-4a1d-841c-ff80eaaccfaa" = true
+
+# full clock and zeroed clock
+"96969ca8-875a-48a1-86ae-257a528c44f5" = true

--- a/exercises/etl/.meta/tests.toml
+++ b/exercises/etl/.meta/tests.toml
@@ -1,0 +1,13 @@
+[canonical-tests]
+
+# single letter
+"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+
+# single score with multiple letters
+"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+
+# multiple scores with multiple letters
+"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+
+# multiple scores with differing numbers of letters
+"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true

--- a/exercises/flatten-array/.meta/tests.toml
+++ b/exercises/flatten-array/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# no nesting
+"d268b919-963c-442d-9f07-82b93f1b518c" = true
+
+# flattens array with just integers present
+"c84440cc-bb3a-48a6-862c-94cf23f2815d" = true
+
+# 5 level nesting
+"d3d99d39-6be5-44f5-a31d-6037d92ba34f" = true
+
+# 6 level nesting
+"d572bdba-c127-43ed-bdcd-6222ac83d9f7" = true
+
+# 6 level nest list with null values
+"ef1d4790-1b1e-4939-a179-51ace0829dbd" = true
+
+# all values in nested list are null
+"85721643-705a-4150-93ab-7ae398e2942d" = true

--- a/exercises/grade-school/.meta/tests.toml
+++ b/exercises/grade-school/.meta/tests.toml
@@ -1,0 +1,22 @@
+[canonical-tests]
+
+# Adding a student adds them to the sorted roster
+"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+
+# Adding more student adds them to the sorted roster
+"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+
+# Adding students to different grades adds them to the same sorted roster
+"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+
+# Roster returns an empty list if there are no students enrolled
+"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+
+# Student names with grades are displayed in the same sorted roster
+"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+
+# Grade returns the students in that grade in alphabetical order
+"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+
+# Grade returns an empty list if there are no students in that grade
+"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# empty strands
+"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+
+# single letter identical strands
+"54681314-eee2-439a-9db0-b0636c656156" = true
+
+# single letter different strands
+"294479a3-a4c8-478f-8d63-6209815a827b" = true
+
+# long identical strands
+"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+
+# long different strands
+"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+
+# disallow first strand longer
+"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+
+# disallow second strand longer
+"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+
+# disallow left empty strand
+"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+
+# disallow right empty strand
+"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,0 +1,4 @@
+[canonical-tests]
+
+# Say Hi!
+"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true

--- a/exercises/leap/.meta/tests.toml
+++ b/exercises/leap/.meta/tests.toml
@@ -1,0 +1,28 @@
+[canonical-tests]
+
+# year not divisible by 4 in common year
+"6466b30d-519c-438e-935d-388224ab5223" = true
+
+# year divisible by 2, not divisible by 4 in common year
+"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+
+# year divisible by 4, not divisible by 100 in leap year
+"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+
+# year divisible by 4 and 5 is still a leap year
+"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+
+# year divisible by 100, not divisible by 400 in common year
+"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+
+# year divisible by 100 but not by 3 is still not a leap year
+"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+
+# year divisible by 400 in leap year
+"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+
+# year divisible by 400 but not by 125 is still a leap year
+"57902c77-6fe9-40de-8302-587b5c27121e" = true
+
+# year divisible by 200, not divisible by 400 in common year
+"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true

--- a/exercises/luhn/.meta/tests.toml
+++ b/exercises/luhn/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# single digit strings can not be valid
+"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+
+# a single zero is invalid
+"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+
+# a simple valid SIN that remains valid if reversed
+"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+
+# a simple valid SIN that becomes invalid if reversed
+"9369092e-b095-439f-948d-498bd076be11" = true
+
+# a valid Canadian SIN
+"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+
+# invalid Canadian SIN
+"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+
+# invalid credit card
+"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+
+# invalid long number with an even remainder
+"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+
+# valid number with an even number of digits
+"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+
+# valid number with an odd number of spaces
+"ef081c06-a41f-4761-8492-385e13c8202d" = true
+
+# valid strings with a non-digit added at the end become invalid
+"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+
+# valid strings with punctuation included become invalid
+"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+
+# valid strings with symbols included become invalid
+"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+
+# single zero with space is invalid
+"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+
+# more than a single zero is valid
+"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+
+# input digit 9 is correctly converted to output digit 9
+"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+
+# using ascii value for non-doubled non-digit isn't allowed
+"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+
+# using ascii value for doubled non-digit isn't allowed
+"f94cf191-a62f-4868-bc72-7253114aa157" = true

--- a/exercises/meetup/.meta/tests.toml
+++ b/exercises/meetup/.meta/tests.toml
@@ -1,0 +1,286 @@
+[canonical-tests]
+
+# monteenth of May 2013
+"d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8" = true
+
+# monteenth of August 2013
+"f78373d1-cd53-4a7f-9d37-e15bf8a456b4" = true
+
+# monteenth of September 2013
+"8c78bea7-a116-425b-9c6b-c9898266d92a" = true
+
+# tuesteenth of March 2013
+"cfef881b-9dc9-4d0b-8de4-82d0f39fc271" = true
+
+# tuesteenth of April 2013
+"69048961-3b00-41f9-97ee-eb6d83a8e92b" = true
+
+# tuesteenth of August 2013
+"d30bade8-3622-466a-b7be-587414e0caa6" = true
+
+# wednesteenth of January 2013
+"8db4b58b-92f3-4687-867b-82ee1a04f851" = true
+
+# wednesteenth of February 2013
+"6c27a2a2-28f8-487f-ae81-35d08c4664f7" = true
+
+# wednesteenth of June 2013
+"008a8674-1958-45b5-b8e6-c2c9960d973a" = true
+
+# thursteenth of May 2013
+"e4abd5e3-57cb-4091-8420-d97e955c0dbd" = true
+
+# thursteenth of June 2013
+"85da0b0f-eace-4297-a6dd-63588d5055b4" = true
+
+# thursteenth of September 2013
+"ecf64f9b-8413-489b-bf6e-128045f70bcc" = true
+
+# friteenth of April 2013
+"ac4e180c-7d0a-4d3d-b05f-f564ebb584ca" = true
+
+# friteenth of August 2013
+"b79101c7-83ad-4f8f-8ec8-591683296315" = true
+
+# friteenth of September 2013
+"6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8" = true
+
+# saturteenth of February 2013
+"dfae03ed-9610-47de-a632-655ab01e1e7c" = true
+
+# saturteenth of April 2013
+"ec02e3e1-fc72-4a3c-872f-a53fa8ab358e" = true
+
+# saturteenth of October 2013
+"d983094b-7259-4195-b84e-5d09578c89d9" = true
+
+# sunteenth of May 2013
+"d84a2a2e-f745-443a-9368-30051be60c2e" = true
+
+# sunteenth of June 2013
+"0e64bc53-92a3-4f61-85b2-0b7168c7ce5a" = true
+
+# sunteenth of October 2013
+"de87652c-185e-4854-b3ae-04cf6150eead" = true
+
+# first Monday of March 2013
+"2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411" = true
+
+# first Monday of April 2013
+"a6168c7c-ed95-4bb3-8f92-c72575fc64b0" = true
+
+# first Tuesday of May 2013
+"1bfc620f-1c54-4bbd-931f-4a1cd1036c20" = true
+
+# first Tuesday of June 2013
+"12959c10-7362-4ca0-a048-50cf1c06e3e2" = true
+
+# first Wednesday of July 2013
+"1033dc66-8d0b-48a1-90cb-270703d59d1d" = true
+
+# first Wednesday of August 2013
+"b89185b9-2f32-46f4-a602-de20b09058f6" = true
+
+# first Thursday of September 2013
+"53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5" = true
+
+# first Thursday of October 2013
+"b420a7e3-a94c-4226-870a-9eb3a92647f0" = true
+
+# first Friday of November 2013
+"61df3270-28b4-4713-bee2-566fa27302ca" = true
+
+# first Friday of December 2013
+"cad33d4d-595c-412f-85cf-3874c6e07abf" = true
+
+# first Saturday of January 2013
+"a2869b52-5bba-44f0-a863-07bd1f67eadb" = true
+
+# first Saturday of February 2013
+"3585315a-d0db-4ea1-822e-0f22e2a645f5" = true
+
+# first Sunday of March 2013
+"c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1" = true
+
+# first Sunday of April 2013
+"1513328b-df53-4714-8677-df68c4f9366c" = true
+
+# second Monday of March 2013
+"49e083af-47ec-4018-b807-62ef411efed7" = true
+
+# second Monday of April 2013
+"6cb79a73-38fe-4475-9101-9eec36cf79e5" = true
+
+# second Tuesday of May 2013
+"4c39b594-af7e-4445-aa03-bf4f8effd9a1" = true
+
+# second Tuesday of June 2013
+"41b32c34-2e39-40e3-b790-93539aaeb6dd" = true
+
+# second Wednesday of July 2013
+"90a160c5-b5d9-4831-927f-63a78b17843d" = true
+
+# second Wednesday of August 2013
+"23b98ce7-8dd5-41a1-9310-ef27209741cb" = true
+
+# second Thursday of September 2013
+"447f1960-27ca-4729-bc3f-f36043f43ed0" = true
+
+# second Thursday of October 2013
+"c9aa2687-300c-4e79-86ca-077849a81bde" = true
+
+# second Friday of November 2013
+"a7e11ef3-6625-4134-acda-3e7195421c09" = true
+
+# second Friday of December 2013
+"8b420e5f-9290-4106-b5ae-022f3e2a3e41" = true
+
+# second Saturday of January 2013
+"80631afc-fc11-4546-8b5f-c12aaeb72b4f" = true
+
+# second Saturday of February 2013
+"e34d43ac-f470-44c2-aa5f-e97b78ecaf83" = true
+
+# second Sunday of March 2013
+"a57d59fd-1023-47ad-b0df-a6feb21b44fc" = true
+
+# second Sunday of April 2013
+"a829a8b0-abdd-4ad1-b66c-5560d843c91a" = true
+
+# third Monday of March 2013
+"501a8a77-6038-4fc0-b74c-33634906c29d" = true
+
+# third Monday of April 2013
+"49e4516e-cf32-4a58-8bbc-494b7e851c92" = true
+
+# third Tuesday of May 2013
+"4db61095-f7c7-493c-85f1-9996ad3012c7" = true
+
+# third Tuesday of June 2013
+"714fc2e3-58d0-4b91-90fd-61eefd2892c0" = true
+
+# third Wednesday of July 2013
+"b08a051a-2c80-445b-9b0e-524171a166d1" = true
+
+# third Wednesday of August 2013
+"80bb9eff-3905-4c61-8dc9-bb03016d8ff8" = true
+
+# third Thursday of September 2013
+"fa52a299-f77f-4784-b290-ba9189fbd9c9" = true
+
+# third Thursday of October 2013
+"f74b1bc6-cc5c-4bf1-ba69-c554a969eb38" = true
+
+# third Friday of November 2013
+"8900f3b0-801a-466b-a866-f42d64667abd" = true
+
+# third Friday of December 2013
+"538ac405-a091-4314-9ccd-920c4e38e85e" = true
+
+# third Saturday of January 2013
+"244db35c-2716-4fa0-88ce-afd58e5cf910" = true
+
+# third Saturday of February 2013
+"dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e" = true
+
+# third Sunday of March 2013
+"be71dcc6-00d2-4b53-a369-cbfae55b312f" = true
+
+# third Sunday of April 2013
+"b7d2da84-4290-4ee6-a618-ee124ae78be7" = true
+
+# fourth Monday of March 2013
+"4276dc06-a1bd-4fc2-b6c2-625fee90bc88" = true
+
+# fourth Monday of April 2013
+"ddbd7976-2deb-4250-8a38-925ac1a8e9a2" = true
+
+# fourth Tuesday of May 2013
+"eb714ef4-1656-47cc-913c-844dba4ebddd" = true
+
+# fourth Tuesday of June 2013
+"16648435-7937-4d2d-b118-c3e38fd084bd" = true
+
+# fourth Wednesday of July 2013
+"de062bdc-9484-437a-a8c5-5253c6f6785a" = true
+
+# fourth Wednesday of August 2013
+"c2ce6821-169c-4832-8d37-690ef5d9514a" = true
+
+# fourth Thursday of September 2013
+"d462c631-2894-4391-a8e3-dbb98b7a7303" = true
+
+# fourth Thursday of October 2013
+"9ff1f7b6-1b72-427d-9ee9-82b5bb08b835" = true
+
+# fourth Friday of November 2013
+"83bae8ba-1c49-49bc-b632-b7c7e1d7e35f" = true
+
+# fourth Friday of December 2013
+"de752d2a-a95e-48d2-835b-93363dac3710" = true
+
+# fourth Saturday of January 2013
+"eedd90ad-d581-45db-8312-4c6dcf9cf560" = true
+
+# fourth Saturday of February 2013
+"669fedcd-912e-48c7-a0a1-228b34af91d0" = true
+
+# fourth Sunday of March 2013
+"648e3849-ea49-44a5-a8a3-9f2a43b3bf1b" = true
+
+# fourth Sunday of April 2013
+"f81321b3-99ab-4db6-9267-69c5da5a7823" = true
+
+# last Monday of March 2013
+"1af5e51f-5488-4548-aee8-11d7d4a730dc" = true
+
+# last Monday of April 2013
+"f29999f2-235e-4ec7-9dab-26f137146526" = true
+
+# last Tuesday of May 2013
+"31b097a0-508e-48ac-bf8a-f63cdcf6dc41" = true
+
+# last Tuesday of June 2013
+"8c022150-0bb5-4a1f-80f9-88b2e2abcba4" = true
+
+# last Wednesday of July 2013
+"0e762194-672a-4bdf-8a37-1e59fdacef12" = true
+
+# last Wednesday of August 2013
+"5016386a-f24e-4bd7-b439-95358f491b66" = true
+
+# last Thursday of September 2013
+"12ead1a5-cdf9-4192-9a56-2229e93dd149" = true
+
+# last Thursday of October 2013
+"7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7" = true
+
+# last Friday of November 2013
+"e47a739e-b979-460d-9c8a-75c35ca2290b" = true
+
+# last Friday of December 2013
+"5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec" = true
+
+# last Saturday of January 2013
+"61e54cba-76f3-4772-a2b1-bf443fda2137" = true
+
+# last Saturday of February 2013
+"8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f" = true
+
+# last Sunday of March 2013
+"0b63e682-f429-4d19-9809-4a45bd0242dc" = true
+
+# last Sunday of April 2013
+"5232307e-d3e3-4afc-8ba6-4084ad987c00" = true
+
+# last Wednesday of February 2012
+"0bbd48e8-9773-4e81-8e71-b9a51711e3c5" = true
+
+# last Wednesday of December 2014
+"fe0936de-7eee-4a48-88dd-66c07ab1fefc" = true
+
+# last Sunday of February 2015
+"2ccf2488-aafc-4671-a24e-2b6effe1b0e2" = true
+
+# first Friday of December 2012
+"00c3ce9f-cf36-4b70-90d8-92b32be6830e" = true

--- a/exercises/nucleotide-count/.meta/tests.toml
+++ b/exercises/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,16 @@
+[canonical-tests]
+
+# empty strand
+"3e5c30a8-87e2-4845-a815-a49671ade970" = true
+
+# can count one nucleotide in single-character input
+"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+
+# strand with repeated nucleotide
+"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true
+
+# strand with multiple nucleotides
+"40a45eac-c83f-4740-901a-20b22d15a39f" = true
+
+# strand with invalid nucleotides
+"b4c47851-ee9e-4b0a-be70-a86e343bd851" = true

--- a/exercises/pangram/.meta/tests.toml
+++ b/exercises/pangram/.meta/tests.toml
@@ -1,0 +1,31 @@
+[canonical-tests]
+
+# empty sentence
+"64f61791-508e-4f5c-83ab-05de042b0149" = true
+
+# perfect lower case
+"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+
+# only lower case
+"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+
+# missing the letter 'x'
+"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+
+# missing the letter 'h'
+"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+
+# with underscores
+"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+
+# with numbers
+"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+
+# missing letters replaced by numbers
+"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+
+# mixed case and punctuation
+"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+
+# case insensitive
+"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true

--- a/exercises/phone-number/.meta/tests.toml
+++ b/exercises/phone-number/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# cleans the number
+"79666dce-e0f1-46de-95a1-563802913c35" = true
+
+# cleans numbers with dots
+"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
+
+# cleans numbers with multiple spaces
+"08f94c34-9a37-46a2-a123-2a8e9727395d" = true
+
+# invalid when 9 digits
+"598d8432-0659-4019-a78b-1c6a73691d21" = true
+
+# invalid when 11 digits does not start with a 1
+"57061c72-07b5-431f-9766-d97da7c4399d" = true
+
+# valid when 11 digits and starting with 1
+"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+
+# valid when 11 digits and starting with 1 even with punctuation
+"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
+
+# invalid when more than 11 digits
+"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = true
+
+# invalid with letters
+"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = true
+
+# invalid with punctuations
+"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
+
+# invalid if area code starts with 0
+"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+
+# invalid if area code starts with 1
+"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+
+# invalid if exchange code starts with 0
+"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+
+# invalid if exchange code starts with 1
+"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+
+# invalid if area code starts with 0 on valid 11-digit number
+"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+
+# invalid if area code starts with 1 on valid 11-digit number
+"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+
+# invalid if exchange code starts with 0 on valid 11-digit number
+"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+
+# invalid if exchange code starts with 1 on valid 11-digit number
+"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true

--- a/exercises/raindrops/.meta/tests.toml
+++ b/exercises/raindrops/.meta/tests.toml
@@ -1,0 +1,55 @@
+[canonical-tests]
+
+# the sound for 1 is 1
+"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+
+# the sound for 3 is Pling
+"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+
+# the sound for 5 is Plang
+"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+
+# the sound for 7 is Plong
+"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+
+# the sound for 6 is Pling as it has a factor 3
+"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+
+# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
+"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+
+# the sound for 9 is Pling as it has a factor 3
+"0dd66175-e3e2-47fc-8750-d01739856671" = true
+
+# the sound for 10 is Plang as it has a factor 5
+"022c44d3-2182-4471-95d7-c575af225c96" = true
+
+# the sound for 14 is Plong as it has a factor of 7
+"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+
+# the sound for 15 is PlingPlang as it has factors 3 and 5
+"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+
+# the sound for 21 is PlingPlong as it has factors 3 and 7
+"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+
+# the sound for 25 is Plang as it has a factor 5
+"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+
+# the sound for 27 is Pling as it has a factor 3
+"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+
+# the sound for 35 is PlangPlong as it has factors 5 and 7
+"bdf061de-8564-4899-a843-14b48b722789" = true
+
+# the sound for 49 is Plong as it has a factor 7
+"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+
+# the sound for 52 is 52
+"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+
+# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
+"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+
+# the sound for 3125 is Plang as it has a factor 5
+"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true

--- a/exercises/rna-transcription/.meta/tests.toml
+++ b/exercises/rna-transcription/.meta/tests.toml
@@ -1,0 +1,19 @@
+[canonical-tests]
+
+# Empty RNA sequence
+"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+
+# RNA complement of cytosine is guanine
+"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+
+# RNA complement of guanine is cytosine
+"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+
+# RNA complement of thymine is adenine
+"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+
+# RNA complement of adenine is uracil
+"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+
+# RNA complement
+"79ed2757-f018-4f47-a1d7-34a559392dbf" = true

--- a/exercises/roman-numerals/.meta/tests.toml
+++ b/exercises/roman-numerals/.meta/tests.toml
@@ -1,0 +1,58 @@
+[canonical-tests]
+
+# 1 is a single I
+"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+
+# 2 is two I's
+"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+
+# 3 is three I's
+"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+
+# 4, being 5 - 1, is IV
+"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+
+# 5 is a single V
+"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+
+# 6, being 5 + 1, is VI
+"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+
+# 9, being 10 - 1, is IX
+"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+
+# 20 is two X's
+"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+
+# 48 is not 50 - 2 but rather 40 + 8
+"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+
+# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
+"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+
+# 50 is a single L
+"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+
+# 90, being 100 - 10, is XC
+"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+
+# 100 is a single C
+"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+
+# 60, being 50 + 10, is LX
+"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+
+# 400, being 500 - 100, is CD
+"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+
+# 500 is a single D
+"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+
+# 900, being 1000 - 100, is CM
+"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+
+# 1000 is a single M
+"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+
+# 3000 is three M's
+"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true

--- a/exercises/scrabble-score/.meta/tests.toml
+++ b/exercises/scrabble-score/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# lowercase letter
+"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = true
+
+# uppercase letter
+"f7794b49-f13e-45d1-a933-4e48459b2201" = true
+
+# valuable letter
+"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = true
+
+# short word
+"f3c8c94e-bb48-4da2-b09f-e832e103151e" = true
+
+# short, valuable word
+"71e3d8fa-900d-4548-930e-68e7067c4615" = true
+
+# medium word
+"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
+
+# medium, valuable word
+"fa20c572-ad86-400a-8511-64512daac352" = true
+
+# long, mixed-case word
+"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = true
+
+# english-like word
+"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = true
+
+# empty input
+"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = true
+
+# entire alphabet available
+"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = true

--- a/exercises/space-age/.meta/tests.toml
+++ b/exercises/space-age/.meta/tests.toml
@@ -1,0 +1,25 @@
+[canonical-tests]
+
+# age on Earth
+"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+
+# age on Mercury
+"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+
+# age on Venus
+"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+
+# age on Mars
+"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+
+# age on Jupiter
+"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+
+# age on Saturn
+"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+
+# age on Uranus
+"999354c1-76f8-4bb5-a672-f317b6436743" = true
+
+# age on Neptune
+"80096d30-a0d4-4449-903e-a381178355d8" = true

--- a/exercises/trinary/.meta/tests.toml
+++ b/exercises/trinary/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# trinary 1 is decimal 1
+"a7a79a9e-5606-454c-9cdb-4f3c0ca46931" = true
+
+# trinary 2 is decimal 2
+"39240078-13e2-4eb8-87c4-aeffa7d64130" = true
+
+# trinary 10 is decimal 3
+"81900d67-7e07-4d41-a71e-86f1cd72ce1f" = true
+
+# trinary 11 is decimal 4
+"7a8d5341-f88a-4c60-9048-4d5e017fa701" = true
+
+# trinary 100 is decimal 9
+"6b3c37f6-d6b3-4575-85c0-19f48dd101af" = true
+
+# trinary 112 is decimal 14
+"a210b2b8-d333-4e19-9e59-87cabdd2a0ba" = true
+
+# trinary 222 is decimal 26
+"5ae03472-b942-42ce-ba00-e84a7dc86dd8" = true
+
+# trinary 1122000120 is decimal 32091
+"d4fabf94-6149-4d1e-b42f-b34dc3ddef8f" = true
+
+# invalid trinary digits returns 0
+"34be152d-38f3-4dcf-b5ab-9e14fe2f7161" = true
+
+# invalid word as input returns 0
+"b57aa24d-3da2-4787-9429-5bc94d3112d6" = true
+
+# invalid numbers with letters as input returns 0
+"673c2057-5d89-483c-87fa-139da6927b90" = true

--- a/exercises/two-fer/.meta/tests.toml
+++ b/exercises/two-fer/.meta/tests.toml
@@ -1,0 +1,10 @@
+[canonical-tests]
+
+# no name given
+"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+
+# a name given
+"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+
+# another name given
+"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true

--- a/exercises/word-count/.meta/tests.toml
+++ b/exercises/word-count/.meta/tests.toml
@@ -1,0 +1,40 @@
+[canonical-tests]
+
+# count one word
+"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+
+# count one of each word
+"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+
+# multiple occurrences of a word
+"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+
+# handles cramped lists
+"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+
+# handles expanded lists
+"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+
+# ignore punctuation
+"a514a0f2-8589-4279-8892-887f76a14c82" = true
+
+# include numbers
+"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+
+# normalize case
+"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+
+# with apostrophes
+"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+
+# with quotations
+"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+
+# substrings from the beginning
+"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+
+# multiple spaces not detected as a word
+"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+
+# alternating word separators not detected as a word
+"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true

--- a/exercises/wordy/.meta/tests.toml
+++ b/exercises/wordy/.meta/tests.toml
@@ -1,0 +1,70 @@
+[canonical-tests]
+
+# just a number
+"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+
+# addition
+"bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
+
+# more addition
+"79e49e06-c5ae-40aa-a352-7a3a01f70015" = true
+
+# addition with negative numbers
+"b345dbe0-f733-44e1-863c-5ae3568f3803" = true
+
+# large addition
+"cd070f39-c4cc-45c4-97fb-1be5e5846f87" = true
+
+# subtraction
+"0d86474a-cd93-4649-a4fa-f6109a011191" = true
+
+# multiplication
+"30bc8395-5500-4712-a0cf-1d788a529be5" = true
+
+# division
+"34c36b08-8605-4217-bb57-9a01472c427f" = true
+
+# multiple additions
+"da6d2ce4-fb94-4d26-8f5f-b078adad0596" = true
+
+# addition and subtraction
+"7fd74c50-9911-4597-be09-8de7f2fea2bb" = true
+
+# multiple subtraction
+"b120ffd5-bad6-4e22-81c8-5512e8faf905" = true
+
+# subtraction then addition
+"4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
+
+# multiple multiplication
+"312d908c-f68f-42c9-aa75-961623cc033f" = true
+
+# addition and multiplication
+"38e33587-8940-4cc1-bc28-bfd7e3966276" = true
+
+# multiple division
+"3c854f97-9311-46e8-b574-92b60d17d394" = true
+
+# unknown operation
+"3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true
+
+# Non math question
+"8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
+
+# reject problem missing an operand
+"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+
+# reject problem with no operands or operators
+"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+
+# reject two operations in a row
+"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+
+# reject two numbers in a row
+"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+
+# reject postfix notation
+"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+
+# reject prefix notation
+"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
