### PR TITLE
Update generator to parse tests from toml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 bin/configlet
 bin/configlet.exe
+bin/canonical_data_syncer
+bin/canonical_data_syncer.exe
 # dir created when a Raku module is used
 .precomp

--- a/META6.json
+++ b/META6.json
@@ -1,4 +1,9 @@
 {
   "name": "exercism/raku",
-  "depends": ["YAMLish", "Template::Mustache"]
+  "depends": [
+    "Config::TOML",
+    "JSON::Fast",
+    "Template::Mustache",
+    "YAMLish"
+  ]
 }

--- a/bin/fetch-canonical_data_syncer
+++ b/bin/fetch-canonical_data_syncer
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eo pipefail
+
+readonly LATEST='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+
+case "$(uname)" in
+    (Darwin*)   OS='mac'     ;;
+    (Linux*)    OS='linux'   ;;
+    (Windows*)  OS='windows' ;;
+    (MINGW*)    OS='windows' ;;
+    (MSYS_NT-*) OS='windows' ;;
+    (*)         OS='linux'   ;;
+esac
+
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+if [ -z "${GITHUB_TOKEN}" ]
+then
+    HEADER=''
+else
+    HEADER="authorization: Bearer ${GITHUB_TOKEN}"
+fi
+
+FILENAME="canonical_data_syncer-${OS}-${ARCH}.${EXT}"
+
+get_url () {
+    curl --header "$HEADER" -s "$LATEST" |
+        awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
+        tr -d '"'
+}
+
+URL=$(get_url)
+
+case "$EXT" in
+    (*zip)
+        curl --header "$HEADER" -s --location "$URL" -o bin/latest-canonical_data_syncer.zip
+        unzip bin/latest-canonical_data_syncer.zip -d bin/
+        rm bin/latest-canonical_data_syncer.zip
+        ;;
+    (*) curl --header "$HEADER" -s --location "$URL" | tar xz -C bin/ ;;
+esac

--- a/exercises/hello-world/.meta/exercise-data.yaml
+++ b/exercises/hello-world/.meta/exercise-data.yaml
@@ -1,6 +1,5 @@
 exercise: HelloWorld
 plan: 1
-ignore_cdata: true
 tests: |-
   # Run the 'is' subroutine from the 'Test' module, with three arguments.
   is(
@@ -8,9 +7,6 @@ tests: |-
     'Hello, World!', # The expected result to compare with 'hello'.
     'Say Hi!'        # The test description.
   );
-
-  =finish
-  Based on canonical data v1.1.0
 
 lib_comment: Look for the module inside the same directory as this test file.
 plan_comment: This is how many tests we expect to run.

--- a/exercises/hello-world/.meta/tests.toml
+++ b/exercises/hello-world/.meta/tests.toml
@@ -1,4 +1,4 @@
 [canonical-tests]
 
 # Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+"af9ffe10-dc13-42d8-a742-e7bdafac449d" = false

--- a/exercises/hello-world/hello-world.rakutest
+++ b/exercises/hello-world/hello-world.rakutest
@@ -10,6 +10,3 @@ is(
   'Hello, World!', # The expected result to compare with 'hello'.
   'Say Hi!'        # The test description.
 );
-
-=finish
-Based on canonical data v1.1.0

--- a/exercises/leap/.meta/exercise-data.yaml
+++ b/exercises/leap/.meta/exercise-data.yaml
@@ -7,7 +7,7 @@ tests: |-
     };
   }
 
-  for $c-data<cases>.values -> %case {
+  for @test-cases -> %case {
     subtest %case<description>, {
       plan 2;
       isa-ok ( my $result := is-leap-year %case<input><year> ), Bool;

--- a/exercises/leap/leap.rakutest
+++ b/exercises/leap/leap.rakutest
@@ -5,14 +5,14 @@ use lib $?FILE.IO.dirname;
 use Leap;
 plan 9;
 
-my $c-data = from-json $=pod.pop.contents;
+my @test-cases = from-json($=pod.pop.contents).List;
 for Date, DateTime {
   .^method_table<is-leap-year>.wrap: sub (|) {
     bail-out 'Built-in `is-leap-year` method is not allowed for this exercise.';
   };
 }
 
-for $c-data<cases>.values -> %case {
+for @test-cases -> %case {
   subtest %case<description>, {
     plan 2;
     isa-ok ( my $result := is-leap-year %case<input><year> ), Bool;
@@ -20,84 +20,80 @@ for $c-data<cases>.values -> %case {
   }
 }
 
-=head2 Canonical Data
+=head2 Test Cases
 =begin code
-{
-  "exercise": "leap",
-  "version": "1.6.0",
-  "cases": [
-    {
-      "description": "year not divisible by 4 in common year",
-      "property": "leapYear",
-      "input": {
-        "year": 2015
-      },
-      "expected": false
+[
+  {
+    "description": "year not divisible by 4 in common year",
+    "expected": false,
+    "input": {
+      "year": 2015
     },
-    {
-      "description": "year divisible by 2, not divisible by 4 in common year",
-      "property": "leapYear",
-      "input": {
-        "year": 1970
-      },
-      "expected": false
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 2, not divisible by 4 in common year",
+    "expected": false,
+    "input": {
+      "year": 1970
     },
-    {
-      "description": "year divisible by 4, not divisible by 100 in leap year",
-      "property": "leapYear",
-      "input": {
-        "year": 1996
-      },
-      "expected": true
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 4, not divisible by 100 in leap year",
+    "expected": true,
+    "input": {
+      "year": 1996
     },
-    {
-      "description": "year divisible by 4 and 5 is still a leap year",
-      "property": "leapYear",
-      "input": {
-        "year": 1960
-      },
-      "expected": true
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 4 and 5 is still a leap year",
+    "expected": true,
+    "input": {
+      "year": 1960
     },
-    {
-      "description": "year divisible by 100, not divisible by 400 in common year",
-      "property": "leapYear",
-      "input": {
-        "year": 2100
-      },
-      "expected": false
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 100, not divisible by 400 in common year",
+    "expected": false,
+    "input": {
+      "year": 2100
     },
-    {
-      "description": "year divisible by 100 but not by 3 is still not a leap year",
-      "property": "leapYear",
-      "input": {
-        "year": 1900
-      },
-      "expected": false
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 100 but not by 3 is still not a leap year",
+    "expected": false,
+    "input": {
+      "year": 1900
     },
-    {
-      "description": "year divisible by 400 in leap year",
-      "property": "leapYear",
-      "input": {
-        "year": 2000
-      },
-      "expected": true
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 400 in leap year",
+    "expected": true,
+    "input": {
+      "year": 2000
     },
-    {
-      "description": "year divisible by 400 but not by 125 is still a leap year",
-      "property": "leapYear",
-      "input": {
-        "year": 2400
-      },
-      "expected": true
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 400 but not by 125 is still a leap year",
+    "expected": true,
+    "input": {
+      "year": 2400
     },
-    {
-      "description": "year divisible by 200, not divisible by 400 in common year",
-      "property": "leapYear",
-      "input": {
-        "year": 1800
-      },
-      "expected": false
-    }
-  ]
-}
+    "property": "leapYear"
+  },
+  {
+    "description": "year divisible by 200, not divisible by 400 in common year",
+    "expected": false,
+    "input": {
+      "year": 1800
+    },
+    "property": "leapYear"
+  }
+]
 =end code

--- a/lib/Exercism/Generator.rakumod
+++ b/lib/Exercism/Generator.rakumod
@@ -1,17 +1,46 @@
 unit class Exercism::Generator;
+
+use Config::TOML;
+use JSON::Fast;
 use Template::Mustache;
 
 my $base-dir = $?FILE.IO.parent.add("../..");
 
-has %.data;
-has Str $.exercise;
-has Str:D $.cdata = '';
+has        %.data;
+has Str    $.exercise;
+has Str:D  $.cdata      = '';
+has Str:D  $.json-tests = '';
+has Hash:D @.cases;
+has @.case-uuids is SetHash;
 
 submethod TWEAK {
-  if $!exercise && %!data<ignore_cdata>.not && (my $cdata-file =
-    $base-dir.add: "problem-specifications/exercises/$!exercise/canonical-data.json") ~~ :f
-  {
-    %!data<cdata><json> := $!cdata = $cdata-file.slurp.trim;
+  if self.exercise {
+    if (my $toml-file =
+      $base-dir.add: "exercises/$(self.exercise)/.meta/tests.toml") ~~ :f
+    {
+      @!case-uuids = |from-toml($toml-file.slurp)<canonical-tests>;
+    }
+
+    if self.case-uuids && (my $cdata-file =
+      $base-dir.add: "problem-specifications/exercises/$!exercise/canonical-data.json") ~~ :f
+    {
+      $!cdata = $cdata-file.slurp.trim;
+      self!populate-cases( from-json(self.cdata) );
+      %!data<cases> := $!json-tests = to-json(self.cases, :sorted-keys);
+    }
+  }
+}
+
+method !populate-cases ( %obj, Str $description = '' --> Nil ) {
+  my Str $new-desc = '';
+  if %obj<cases>.defined {
+    $new-desc = $description ~ %obj<description> ~ ': ' if %obj<description>;
+    self!populate-cases( $_, $new-desc || $description ) for %obj<cases>.values;
+  }
+  elsif %obj<uuid> ∈ self.case-uuids {
+    @!cases.push(
+      %(|(%obj<input expected property>:p), description => $description ~ %obj<description>)
+    );
   }
 }
 

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -1,6 +1,6 @@
 #!/usr/bin/env raku{{=#`{{ }}=}}#`{{! Mustache tags double up as Raku embedded comments}}
-use Test;#`{{#cdata}}
-use JSON::Fast;#`{{/cdata}}#`{{#modules}}
+use Test;#`{{#cases}}
+use JSON::Fast;#`{{/cases}}#`{{#modules}}
 use #`{{&use}};#`{{/modules}}
 use lib $?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}
 use #`{{&exercise}};#`{{#plan}}
@@ -12,8 +12,8 @@ subtest 'Class methods', {
     can-ok #`{{&exercise}}, $method;
   }
 } or bail-out 'Cannot run expected method(s).';
-#`{{/methods}}#`{{#cdata}}
-my $c-data = from-json $=pod.pop.contents;#`{{/cdata}}
+#`{{/methods}}#`{{#cases}}
+my @test-cases = from-json($=pod.pop.contents).List;#`{{/cases}}
 #`{{&tests}}#`{{#catch_stub}}
 
 CATCH {
@@ -22,9 +22,9 @@ CATCH {
     note "{.message} (does the sub/method contain '!!!'?)\n"
       ~ .backtrace.concise;
   }
-}#`{{/catch_stub}}#`{{#cdata}}
+}#`{{/catch_stub}}#`{{#cases}}
 
-=head2 Canonical Data
+=head2 Test Cases
 =begin code
-#`{{&json}}
-=end code#`{{/cdata}}
+#`{{&cases}}
+=end code#`{{/cases}}


### PR DESCRIPTION
The generator now creates an array of test cases using the uuids from `tests.toml`.

`hello-world` is custom written to keep the test file simple, so its case has been excluded.

`leap` has been generated using the toml file.