### PR TITLE
Set attribute defaults without TWEAK submethod; Move file creation into generator module

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -23,8 +23,8 @@ jobs:
       - run: zef install --/test --deps-only .
 
       - name: Test generator
-        run: prove6 t/generator.rakutest
+        run: prove6 t/generator
 
       - name: Generated files match generator output
-        run: prove6 t/generated-tests.rakutest
+        run: prove6 t/files
         continue-on-error: true

--- a/bin/exercise-gen.raku
+++ b/bin/exercise-gen.raku
@@ -64,42 +64,7 @@ sub generate ($exercise) {
 
   print "Generating $exercise... ";
 
-  given Exercism::Generator.new(
-    :$exercise, data => load-yaml $yaml-file.absolute.IO.slurp
-  ) {
-    my $testfile = $exercise-dir.add("$exercise.rakutest");
-    $testfile.spurt(.test);
-    $testfile.chmod(0o755);
-
-    $exercise-dir.add("{.package}.rakumod").spurt(.stub);
-
-    $exercise-dir.add('.meta/solutions').mkdir;
-    for .examples.pairs -> $example {
-      if $example.key ~~ 'base' {
-        $exercise-dir
-          .add(".meta/solutions/{.package}.rakumod")
-          .spurt($example.value);
-        # This emulates Raku's symlink, which does not yet support non-absolute paths
-        try nqp::symlink(
-          "../../$_",
-          nqp::unbox_s( $exercise-dir.add(".meta/solutions/$_").absolute )
-        ) given $testfile.basename;
-      }
-      else {
-        $exercise-dir
-          .add(".meta/solutions/{$example.key}")
-          .mkdir;
-        $exercise-dir
-          .add(".meta/solutions/{$example.key}/{.package}.rakumod")
-          .spurt($example.value);
-        # This emulates Raku's symlink, which does not yet support non-absolute paths
-        try nqp::symlink(
-          "../../../$_",
-          nqp::unbox_s( $exercise-dir.add(".meta/solutions/{$example.key}/$_").absolute )
-        ) given $testfile.basename;
-      }
-    }
-  }
+  Exercism::Generator.new(:$exercise).create-files;
 
   say 'Generated.';
 }

--- a/t/files/generated-tests.rakutest
+++ b/t/files/generated-tests.rakutest
@@ -1,7 +1,7 @@
 #!/usr/bin/env raku
 use Test;
 use YAMLish;
-use lib ( my $base-dir = $?FILE.IO.resolve.parent(2) ).add('lib');
+use lib ( my $base-dir = $?FILE.IO.resolve.parent(3) ).add('lib');
 use Exercism::Generator;
 
 bail-out if $base-dir.add('problem-specifications') !~~ :d;

--- a/t/files/generated-tests.rakutest
+++ b/t/files/generated-tests.rakutest
@@ -4,7 +4,7 @@ use YAMLish;
 use lib ( my $base-dir = $?FILE.IO.resolve.parent(3) ).add('lib');
 use Exercism::Generator;
 
-bail-out if $base-dir.add('problem-specifications') !~~ :d;
+bail-out if $base-dir.add('.problem-specifications') !~~ :d;
 for $base-dir.add('exercises').dir.sort {
   if .add('.meta/exercise-data.yaml') ~~ :f {
     is .add("{.basename}.rakutest").slurp,

--- a/t/generator.rakutest
+++ b/t/generator.rakutest
@@ -2,10 +2,48 @@ use Test;
 use lib ( my $base-dir = $?FILE.IO.resolve.parent(2) ).add('lib');
 use Exercism::Generator;
 
+subtest 'Rendered test files' => {
+  plan 3;
+
+  given new-generator() {
+    is .test, q:to/TEST/, 'No data';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      done-testing;
+      TEST
+ }
+
+  given new-generator( :data(:plan(1)) ) {
+    is .test, q:to/TEST/, 'A plan';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+      plan 1;
+      TEST
+ }
+
+  given new-generator( :data(:tests('ok True;')) ) {
+    is .test, q:to/TEST/, 'A test';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      ok True;
+
+      done-testing;
+      TEST
+  }
+}
+
 subtest '0 case UUIDs' => {
   plan 4;
 
-  given Exercism::Generator.new(
+  given new-generator(
     :exercise<hello-world>,
     :case-uuids(),
   ) {
@@ -19,7 +57,7 @@ subtest '0 case UUIDs' => {
 subtest '1 case UUID' => {
   plan 4;
 
-  given Exercism::Generator.new(
+  given new-generator(
     :exercise<hello-world>,
     :case-uuids(<af9ffe10-dc13-42d8-a742-e7bdafac449d>),
     :data(:package<TEST>),
@@ -55,3 +93,7 @@ subtest '1 case UUID' => {
 }
 
 done-testing;
+
+sub new-generator (|c) {
+  Exercism::Generator.new( :exercise<test-exercise>, |c )
+}

--- a/t/generator/methods.rakutest
+++ b/t/generator/methods.rakutest
@@ -1,49 +1,11 @@
 use Test;
-use lib ( my $base-dir = $?FILE.IO.resolve.parent(2) ).add('lib');
+use lib ( my $base-dir = $?FILE.IO.resolve.parent(3) ).add('lib');
 use Exercism::Generator;
-
-subtest 'Rendered test files' => {
-  plan 3;
-
-  given new-generator() {
-    is .test, q:to/TEST/, 'No data';
-      #!/usr/bin/env raku
-      use Test;
-      use lib $?FILE.IO.dirname;
-      use TestExercise;
-
-      done-testing;
-      TEST
- }
-
-  given new-generator( :data(:plan(1)) ) {
-    is .test, q:to/TEST/, 'A plan';
-      #!/usr/bin/env raku
-      use Test;
-      use lib $?FILE.IO.dirname;
-      use TestExercise;
-      plan 1;
-      TEST
- }
-
-  given new-generator( :data(:tests('ok True;')) ) {
-    is .test, q:to/TEST/, 'A test';
-      #!/usr/bin/env raku
-      use Test;
-      use lib $?FILE.IO.dirname;
-      use TestExercise;
-
-      ok True;
-
-      done-testing;
-      TEST
-  }
-}
 
 subtest '0 case UUIDs' => {
   plan 4;
 
-  given new-generator(
+  given Exercism::Generator.new(
     :exercise<hello-world>,
     :case-uuids(),
   ) {
@@ -57,7 +19,7 @@ subtest '0 case UUIDs' => {
 subtest '1 case UUID' => {
   plan 4;
 
-  given new-generator(
+  given Exercism::Generator.new(
     :exercise<hello-world>,
     :case-uuids(<af9ffe10-dc13-42d8-a742-e7bdafac449d>),
     :data(:package<TEST>),
@@ -93,7 +55,3 @@ subtest '1 case UUID' => {
 }
 
 done-testing;
-
-sub new-generator (|c) {
-  Exercism::Generator.new( :exercise<test-exercise>, |c )
-}

--- a/t/generator/renders.rakutest
+++ b/t/generator/renders.rakutest
@@ -47,7 +47,7 @@ subtest 'Rendered test files' => {
       use lib $?FILE.IO.dirname;
       use TestExercise;
 
-      my @test-cases = from-json($=pod.pop.contents).List;
+      my @test-cases = from-json($=pod[*-1].contents).List;
 
       done-testing;
 
@@ -69,7 +69,7 @@ subtest 'Rendered test files' => {
       use lib $?FILE.IO.dirname;
       use TestExercise;
 
-      my @test-cases = from-json($=pod.pop.contents).List;
+      my @test-cases = from-json($=pod[*-1].contents).List;
       ok $_ for @test-cases;
 
       done-testing;

--- a/t/generator/renders.rakutest
+++ b/t/generator/renders.rakutest
@@ -1,0 +1,89 @@
+use Test;
+use lib ( my $base-dir = $?FILE.IO.resolve.parent(3) ).add('lib');
+use Exercism::Generator;
+
+subtest 'Rendered test files' => {
+  plan 5;
+
+  given new-generator() {
+    is .test, q:to/TEST/, 'No data';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      done-testing;
+      TEST
+ }
+
+  given new-generator( :data(:plan(1)) ) {
+    is .test, q:to/TEST/, 'A plan';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+      plan 1;
+      TEST
+ }
+
+  given new-generator( :data(:tests('ok True;')) ) {
+    is .test, q:to/TEST/, 'A test';
+      #!/usr/bin/env raku
+      use Test;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      ok True;
+
+      done-testing;
+      TEST
+  }
+
+  given new-generator( :json-tests<[]> ) {
+    is .test, q:to/TEST/, 'JSON tests';
+      #!/usr/bin/env raku
+      use Test;
+      use JSON::Fast;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      my @test-cases = from-json($=pod.pop.contents).List;
+
+      done-testing;
+
+      =head2 Test Cases
+      =begin code
+      []
+      =end code
+      TEST
+  }
+
+  given new-generator(
+    :data(:tests('ok $_ for @test-cases;')),
+    :json-tests<[true]>,
+  ) {
+    is .test, q:to/TEST/, 'Tests with JSON';
+      #!/usr/bin/env raku
+      use Test;
+      use JSON::Fast;
+      use lib $?FILE.IO.dirname;
+      use TestExercise;
+
+      my @test-cases = from-json($=pod.pop.contents).List;
+      ok $_ for @test-cases;
+
+      done-testing;
+
+      =head2 Test Cases
+      =begin code
+      [true]
+      =end code
+      TEST
+  }
+}
+
+done-testing;
+
+sub new-generator (|c) {
+  Exercism::Generator.new( :exercise<test-exercise>, |c )
+}

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -4,17 +4,19 @@ use JSON::Fast;#`{{/cases}}#`{{#modules}}
 use #`{{&use}};#`{{/modules}}
 use lib $?FILE.IO.dirname;#`{{#lib_comment}} #`[#`{{&lib_comment}}]#`{{/lib_comment}}
 use #`{{&package}};#`{{#plan}}
-plan #`{{&plan}};#`{{#plan_comment}} #`[#`{{&plan_comment}}]#`{{/plan_comment}}#`{{/plan}}
-#`{{#methods}}#`{{#methods_comment}}
-#`[#`{{&methods_comment}}]#`{{/methods_comment}}
-subtest 'Class methods', {
+plan #`{{&plan}};#`{{#plan_comment}} #`[#`{{&plan_comment}}]#`{{/plan_comment}}#`{{/plan}}#`{{#methods}}
+
+#`{{#methods_comment}}#`[#`{{&methods_comment}}]
+#`{{/methods_comment}}subtest 'Class methods', {
   for <#`{{&methods}}> -> $method {
     can-ok #`{{&package}}, $method;
   }
-} or bail-out 'Cannot run expected method(s).';
-#`{{/methods}}#`{{#cases}}
-my @test-cases = from-json($=pod[*-1].contents).List;#`{{/cases}}
-#`{{&tests}}#`{{#catch_stub}}
+} or bail-out 'Cannot run expected method(s).';#`{{/methods}}#`{{#cases}}
+
+my @test-cases = from-json($=pod[*-1].contents).List;#`{{/cases}}#`{{#tests}}#`{{^cases}}
+#`{{/cases}}
+
+#`{{&tests}}#`{{/tests}}#`{{#catch_stub}}
 
 CATCH {
   when X::StubCode {
@@ -22,7 +24,9 @@ CATCH {
     note "{.message} (does the sub/method contain '!!!'?)\n"
       ~ .backtrace.concise;
   }
-}#`{{/catch_stub}}#`{{#cases}}
+}#`{{/catch_stub}}#`{{^plan}}
+
+done-testing;#`{{/plan}}#`{{#cases}}
 
 =head2 Test Cases
 =begin code


### PR DESCRIPTION
Rather than having the `TWEAK` method responsible for setting all the attribute defaults, each attribute handles its own default.

`bin/exercise-gen.raku` was previously responsible for creating the files after using the generator module to render the templates. The module now has its own method to handle this.