### PR TITLE
Use index on pod variable to avoid modification

### DIFF
--- a/exercises/practice/acronym/acronym.rakutest
+++ b/exercises/practice/acronym/acronym.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Acronym;
 plan 9;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is abbreviate(%case<input><phrase>), |%case<expected description>;
 }

--- a/exercises/practice/all-your-base/all-your-base.rakutest
+++ b/exercises/practice/all-your-base/all-your-base.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use AllYourBase;
 plan 21;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   my &call-convert-base := -> {
     convert-base(

--- a/exercises/practice/allergies/allergies.rakutest
+++ b/exercises/practice/allergies/allergies.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Allergies;
 plan 49;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<property> {
     when 'allergicTo' {

--- a/exercises/practice/anagram/anagram.rakutest
+++ b/exercises/practice/anagram/anagram.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Anagram;
 plan 14;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   cmp-ok match-anagrams( |%case<input>:p ),
     '~~', %case<expected>.Set, %case<description>;

--- a/exercises/practice/atbash-cipher/atbash-cipher.rakutest
+++ b/exercises/practice/atbash-cipher/atbash-cipher.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use AtbashCipher;
 plan 14;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is &::(%case<property>)(%case<input><phrase>),
     |%case<expected description>;

--- a/exercises/practice/bob/bob.rakutest
+++ b/exercises/practice/bob/bob.rakutest
@@ -13,7 +13,7 @@ subtest 'Class methods', {
   }
 } or bail-out 'Cannot run expected method(s).';
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 # Go through the cases and check that Bob gives us the correct responses.
 for @test-cases -> %case {
   is Bob.hey(%case<input><heyBob>), |%case<expected description>;

--- a/exercises/practice/clock/clock.rakutest
+++ b/exercises/practice/clock/clock.rakutest
@@ -11,7 +11,7 @@ subtest 'Class methods', {
   }
 } or bail-out 'Cannot run expected method(s).';
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<property> {
 

--- a/exercises/practice/etl/etl.rakutest
+++ b/exercises/practice/etl/etl.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use ETL;
 plan 4;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 =head2 Notes
 =begin para
 The test expects your returned C<Hash> to have

--- a/exercises/practice/flatten-array/flatten-array.rakutest
+++ b/exercises/practice/flatten-array/flatten-array.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use FlattenArray;
 plan 6;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is-deeply flatten-array(%case<input><array>), |%case<expected description>;
 }

--- a/exercises/practice/grade-school/grade-school.rakutest
+++ b/exercises/practice/grade-school/grade-school.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use GradeSchool;
 plan 7;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   cmp-ok
     roster( |%(<students grade> Z=> %case<input><students desiredGrade>:v) ),

--- a/exercises/practice/grains/grains.rakutest
+++ b/exercises/practice/grains/grains.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Grains;
 plan 11;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<property> {
     when 'square' {

--- a/exercises/practice/hamming/hamming.rakutest
+++ b/exercises/practice/hamming/hamming.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Hamming;
 plan 9;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<expected> {
     when .<error>.so {

--- a/exercises/practice/leap/leap.rakutest
+++ b/exercises/practice/leap/leap.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Leap;
 plan 9;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for Date, DateTime {
   .^method_table<is-leap-year>.wrap: sub (|) {
     bail-out 'Built-in `is-leap-year` method is not allowed for this exercise.';

--- a/exercises/practice/luhn/luhn.rakutest
+++ b/exercises/practice/luhn/luhn.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Luhn;
 plan 18;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   subtest %case<description>, {
     plan 2;

--- a/exercises/practice/meetup/meetup.rakutest
+++ b/exercises/practice/meetup/meetup.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Meetup;
 plan 95;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 =head2 Notes
 =begin para
 This exercise expects you to parse the description string

--- a/exercises/practice/nucleotide-count/nucleotide-count.rakutest
+++ b/exercises/practice/nucleotide-count/nucleotide-count.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use NucleotideCount;
 plan 5;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<expected> {
     when .<error>.so {

--- a/exercises/practice/pangram/pangram.rakutest
+++ b/exercises/practice/pangram/pangram.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Pangram;
 plan 10;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   subtest %case<description>, {
     plan 2;

--- a/exercises/practice/phone-number/phone-number.rakutest
+++ b/exercises/practice/phone-number/phone-number.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Phone;
 plan 18;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<expected> {
     when Str {

--- a/exercises/practice/raindrops/raindrops.rakutest
+++ b/exercises/practice/raindrops/raindrops.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Raindrops;
 plan 18;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   subtest %case<description>, {
     plan 2;

--- a/exercises/practice/rna-transcription/rna-transcription.rakutest
+++ b/exercises/practice/rna-transcription/rna-transcription.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use RNA;
 plan 6;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is to-rna(%case<input><dna>), |%case<expected description>;
 }

--- a/exercises/practice/roman-numerals/roman-numerals.rakutest
+++ b/exercises/practice/roman-numerals/roman-numerals.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use RomanNumerals;
 plan 19;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is to-roman(%case<input><number>), |%case<expected description>;
 }

--- a/exercises/practice/scrabble-score/scrabble-score.rakutest
+++ b/exercises/practice/scrabble-score/scrabble-score.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Scrabble;
 plan 11;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is score(%case<input><word>), |%case<expected description>;
 }

--- a/exercises/practice/space-age/space-age.rakutest
+++ b/exercises/practice/space-age/space-age.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use SpaceAge;
 plan 8;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   is ::(%case<input><planet>).age-on(%case<input><seconds>),
     |%case<expected description>;

--- a/exercises/practice/two-fer/two-fer.rakutest
+++ b/exercises/practice/two-fer/two-fer.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as t
 use TwoFer;
 plan 3; #`[This is how many tests we expect to run.]
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 # Go through the cases and check that &two-fer gives us the correct response.
 for @test-cases -> %case {
   is do {

--- a/exercises/practice/word-count/word-count.rakutest
+++ b/exercises/practice/word-count/word-count.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use WordCount;
 plan 13;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   cmp-ok count-words(%case<input><sentence>),
     '~~', %case<expected>.Bag, %case<description>;

--- a/exercises/practice/wordy/wordy.rakutest
+++ b/exercises/practice/wordy/wordy.rakutest
@@ -5,7 +5,7 @@ use lib $?FILE.IO.dirname;
 use Wordy;
 plan 23;
 
-my @test-cases = from-json($=pod.pop.contents).List;
+my @test-cases = from-json($=pod[*-1].contents).List;
 for @test-cases -> %case {
   given %case<expected> {
     when .<error>.so {

--- a/templates/test.mustache
+++ b/templates/test.mustache
@@ -13,7 +13,7 @@ subtest 'Class methods', {
   }
 } or bail-out 'Cannot run expected method(s).';
 #`{{/methods}}#`{{#cases}}
-my @test-cases = from-json($=pod.pop.contents).List;#`{{/cases}}
+my @test-cases = from-json($=pod[*-1].contents).List;#`{{/cases}}
 #`{{&tests}}#`{{#catch_stub}}
 
 CATCH {


### PR DESCRIPTION
The `$=pod` variable contains documentation embedded in the file. The `.pop` method modifies this variable. This has been replaced with an index to avoid this modification.