### PR TITLE
fetch-canonical_data_syncer: Download v0.17.0, not latest

### DIFF
--- a/bin/fetch-canonical_data_syncer
+++ b/bin/fetch-canonical_data_syncer
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-readonly LATEST='https://api.github.com/repos/exercism/canonical-data-syncer/releases/latest'
+readonly FINAL_RELEASE='https://api.github.com/repos/exercism/canonical-data-syncer/releases/33439231' # v0.17.0
 
 case "$(uname)" in
     (Darwin*)   OS='mac'     ;;
@@ -35,7 +35,7 @@ fi
 FILENAME="canonical_data_syncer-${OS}-${ARCH}.${EXT}"
 
 get_url () {
-    curl --header "$HEADER" -s "$LATEST" |
+    curl --header "$HEADER" -s --location "${FINAL_RELEASE}" |
         awk -v filename=$FILENAME '$1 ~ /browser_download_url/ && $2 ~ filename { print $2 }' |
         tr -d '"'
 }


### PR DESCRIPTION
This commit alters the `fetch-canonical_data_syncer` script so that it
will stay working after we make changes to the `canonical-data-syncer`
repo.

The plan for those changes is:
1. Rename the existing `canonical-data-syncer` repo to `configlet-v3`.
2. Use that repo to develop `configlet` for Exercism v3. The existing
   functionality will be adapted into a `configlet`-style CLI with a
   `sync` subcommand.
3. When Exercism v3 is launched, rename the existing `configlet` repo to
   `configlet-v2`, and the `configlet-v3` repo to `configlet`.

After step 1, GitHub will redirect `canonical-data-syncer` traffic to
the renamed repo. However, the fetch script was implemented to download
the latest release, and in future the latest release will not be
backwards-compatible with `canonical-data-syncer`: it will instead have
a `configlet`-style CLI with a `sync` subcommand.

Therefore, this commit alters the fetch script so that it downloads the
final release of `canonical-data-syncer`. We hard-code the download by
`id`, rather than by tag, giving us the option to start the
`configlet_v3` versioning at `v0.1.0`. We must also add the `--location`
flag to the first `curl` command so that it follows redirects.

In the future, track repos can remove the `fetch-canonical_data_syncer`
script by either:
- adding the upcoming `fetch-configlet_v3` script
- or simply waiting until the `sync` functionality is available in the
  repo located at `exercism/configlet`.

Pinging @ErikSchierboom 