### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,3 +1,5 @@
+# Readme
+
 The `exercise-gen.raku` file can be used in the following ways:
 * From within the directory of the exercise you wish to generate a test for. [showterm example](http://showterm.io/cc7ddb7b23bb73e784d7d)
 * With arguments specifying which exercises you want to generate tests for.  

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Raku (formerly known as Perl 6) is a clean, modern, multi-paradigm language; it offers procedural, object-oriented AND functional programming methodologies.
 It is a supremely flexible language, adapting to your style of programming, whether that be quick one­liners for sysadmins, scripts to manage a database import, or the full stack of modules necessary to realise an entire website.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,2 +1,2 @@
-## Installing Rakudo Star
+# Installing Rakudo Star
 The [Rakudo Files](https://rakudo.org/files) page contains detailed instructions for downloading and installing Rakudo Star for Windows / Mac OS X / Linux.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Learning Raku (formerly Perl 6)
 
 The [Resources](https://raku.org/resources/) page on [raku.org](https://raku.org/) contains a 'For Newcomers' section with a selection of useful material to get you up and running.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,3 @@
-## Useful Raku Resources
+# Useful Raku Resources
 
 [The Raku site](https://raku.org/) has a [resources](https://raku.org/resources/) page containing variety of information on the language, such as guides for newcomers, documentation, and screencasts.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ## Run All Tests
 
 There is a Raku script with the extension `.rakutest`, which will be used to test


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
