### PR TITLE
Use consistent testing pattern across exercises

### DIFF
--- a/exercises/practice/acronym/.meta/exercise-data.yaml
+++ b/exercises/practice/acronym/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   abbreviate:
     test: |-
       sprintf(q:to/END/, (%case<input><phrase>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           abbreviate(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/acronym/acronym.rakutest
+++ b/exercises/practice/acronym/acronym.rakutest
@@ -3,56 +3,65 @@ use Test;
 use lib $?FILE.IO.dirname;
 use Acronym;
 
-is(
+cmp-ok(
     abbreviate("Portable Network Graphics"),
+    "eq",
     "PNG",
     "basic",
 );
 
-is(
+cmp-ok(
     abbreviate("Ruby on Rails"),
+    "eq",
     "ROR",
     "lowercase words",
 );
 
-is(
+cmp-ok(
     abbreviate("First In, First Out"),
+    "eq",
     "FIFO",
     "punctuation",
 );
 
-is(
+cmp-ok(
     abbreviate("GNU Image Manipulation Program"),
+    "eq",
     "GIMP",
     "all caps word",
 );
 
-is(
+cmp-ok(
     abbreviate("Complementary metal-oxide semiconductor"),
+    "eq",
     "CMOS",
     "punctuation without whitespace",
 );
 
-is(
+cmp-ok(
     abbreviate("Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me"),
+    "eq",
     "ROTFLSHTMDCOALM",
     "very long abbreviation",
 );
 
-is(
+cmp-ok(
     abbreviate("Something - I made up from thin air"),
+    "eq",
     "SIMUFTA",
     "consecutive delimiters",
 );
 
-is(
+cmp-ok(
     abbreviate("Halley's Comet"),
+    "eq",
     "HC",
     "apostrophes",
 );
 
-is(
+cmp-ok(
     abbreviate("The Road _Not_ Taken"),
+    "eq",
     "TRNT",
     "underscore emphasis",
 );

--- a/exercises/practice/affine-cipher/.meta/exercise-data.yaml
+++ b/exercises/practice/affine-cipher/.meta/exercise-data.yaml
@@ -9,8 +9,9 @@ properties:
       }
       else {
           sprintf(q:to/END/, (|(%case<input><key><a b>:p), %case<input><phrase>, |(%case<expected description>)).map(*.raku));
-          is(
+          cmp-ok(
               AffineCipher.new( %s, %s ).encode(%s),
+              "eq",
               %s,
               %s,
           );
@@ -25,8 +26,9 @@ properties:
       }
       else {
           sprintf(q:to/END/, (|(%case<input><key><a b>:p), %case<input><phrase>, |(%case<expected description>)).map(*.raku));
-          is(
+          cmp-ok(
               AffineCipher.new( %s, %s ).decode(%s),
+              "eq",
               %s,
               %s,
           );

--- a/exercises/practice/affine-cipher/affine-cipher.rakutest
+++ b/exercises/practice/affine-cipher/affine-cipher.rakutest
@@ -7,88 +7,102 @@ for <encode decode> -> $method {
   AffineCipher.^can($method) or bail-out "Cannot run expected method `$method`.";
 }
 
-is(
+cmp-ok(
     AffineCipher.new( :a(5), :b(7) ).encode("yes"),
+    "eq",
     "xbt",
     "encode: encode yes",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(15), :b(18) ).encode("no"),
+    "eq",
     "fu",
     "encode: encode no",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(21), :b(3) ).encode("OMG"),
+    "eq",
     "lvz",
     "encode: encode OMG",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(25), :b(47) ).encode("O M G"),
+    "eq",
     "hjp",
     "encode: encode O M G",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(11), :b(15) ).encode("mindblowingly"),
+    "eq",
     "rzcwa gnxzc dgt",
     "encode: encode mindblowingly",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(3), :b(4) ).encode("Testing,1 2 3, testing."),
+    "eq",
     "jqgjc rw123 jqgjc rw",
     "encode: encode numbers",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(5), :b(17) ).encode("Truth is fiction."),
+    "eq",
     "iynia fdqfb ifje",
     "encode: encode deep thought",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(17), :b(33) ).encode("The quick brown fox jumps over the lazy dog."),
+    "eq",
     "swxtj npvyk lruol iejdc blaxk swxmh qzglf",
     "encode: encode all the letters",
 );
 
 dies-ok { AffineCipher.new( :a(6), :b(17) ) }, "encode: encode with a not coprime to m";
 
-is(
+cmp-ok(
     AffineCipher.new( :a(3), :b(7) ).decode("tytgn fjr"),
+    "eq",
     "exercism",
     "decode: decode exercism",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(19), :b(16) ).decode("qdwju nqcro muwhn odqun oppmd aunwd o"),
+    "eq",
     "anobstacleisoftenasteppingstone",
     "decode: decode a sentence",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(25), :b(7) ).decode("odpoz ub123 odpoz ub"),
+    "eq",
     "testing123testing",
     "decode: decode numbers",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(17), :b(33) ).decode("swxtj npvyk lruol iejdc blaxk swxmh qzglf"),
+    "eq",
     "thequickbrownfoxjumpsoverthelazydog",
     "decode: decode all the letters",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(17), :b(33) ).decode("swxtjnpvyklruoliejdcblaxkswxmhqzglf"),
+    "eq",
     "thequickbrownfoxjumpsoverthelazydog",
     "decode: decode with no spaces in input",
 );
 
-is(
+cmp-ok(
     AffineCipher.new( :a(15), :b(16) ).decode("vszzm    cly   yd cg    qdp"),
+    "eq",
     "jollygreengiant",
     "decode: decode with too many spaces",
 );

--- a/exercises/practice/all-your-base/.meta/exercise-data.yaml
+++ b/exercises/practice/all-your-base/.meta/exercise-data.yaml
@@ -2,7 +2,7 @@ properties:
   rebase:
     test: |-
       if %case<expected><error>:exists {
-          sprintf(q:to/END/, (|(<from to> Z=> %case<input><inputBase outputBase>), %case<input><digits><>, %case<description>).map(*.raku));
+          sprintf(q:to/END/, (|(<from to> Z=> %case<input><inputBase outputBase>), %case<input><digits>.List<>, %case<description>).map(*.raku));
           dies-ok(
               { convert-base bases => { %s, %s }, digits => %s },
               %s,
@@ -10,10 +10,10 @@ properties:
           END
       }
       else {
-          sprintf(q:to/END/, (|(<from to> Z=> %case<input><inputBase outputBase>), %case<input><digits><>, %case<expected><>, %case<description>).map(*.raku));
+          sprintf(q:to/END/, (|(<from to> Z=> %case<input><inputBase outputBase>), %case<input><digits>.List<>, %case<expected>.List<>, %case<description>).map(*.raku));
           cmp-ok(
               convert-base( bases => { %s, %s }, digits => %s ),
-              '~~',
+              "eqv",
               %s,
               %s,
           );
@@ -25,7 +25,7 @@ example: |-
   sub convert-base (
     :%bases!  where { all(.keys ~~ <from to>.Set, .values.all > 1) },
     :@digits! where { %bases<from> > .all ~~ UInt:D },
-    --> Array[UInt:D]
+    --> List()
   ) is export {
     from-decimal %bases<to>, to-decimal(%bases<from>, @digits);
   }
@@ -44,7 +44,7 @@ example: |-
       unshift @output-digits, $num % $output-base;
       $num div= $output-base;
     }
-    @output-digits.unshift: $num;
+    @output-digits.unshift($num).List;
   }
 
 stub: |-

--- a/exercises/practice/all-your-base/.meta/solutions/AllYourBase.rakumod
+++ b/exercises/practice/all-your-base/.meta/solutions/AllYourBase.rakumod
@@ -3,7 +3,7 @@ unit module AllYourBase;
 sub convert-base (
   :%bases!  where { all(.keys ~~ <from to>.Set, .values.all > 1) },
   :@digits! where { %bases<from> > .all ~~ UInt:D },
-  --> Array[UInt:D]
+  --> List()
 ) is export {
   from-decimal %bases<to>, to-decimal(%bases<from>, @digits);
 }
@@ -22,5 +22,5 @@ sub from-decimal ($output-base, $num is copy) {
     unshift @output-digits, $num % $output-base;
     $num div= $output-base;
   }
-  @output-digits.unshift: $num;
+  @output-digits.unshift($num).List;
 }

--- a/exercises/practice/all-your-base/all-your-base.rakutest
+++ b/exercises/practice/all-your-base/all-your-base.rakutest
@@ -4,131 +4,131 @@ use lib $?FILE.IO.dirname;
 use AllYourBase;
 
 cmp-ok(
-    convert-base( bases => { :from(2), :to(10) }, digits => [1] ),
-    '~~',
-    [1],
+    convert-base( bases => { :from(2), :to(10) }, digits => (1,) ),
+    "eqv",
+    (1,),
     "single bit one to decimal",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(2), :to(10) }, digits => [1, 0, 1] ),
-    '~~',
-    [5],
+    convert-base( bases => { :from(2), :to(10) }, digits => (1, 0, 1) ),
+    "eqv",
+    (5,),
     "binary to single decimal",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(10), :to(2) }, digits => [5] ),
-    '~~',
-    [1, 0, 1],
+    convert-base( bases => { :from(10), :to(2) }, digits => (5,) ),
+    "eqv",
+    (1, 0, 1),
     "single decimal to binary",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(2), :to(10) }, digits => [1, 0, 1, 0, 1, 0] ),
-    '~~',
-    [4, 2],
+    convert-base( bases => { :from(2), :to(10) }, digits => (1, 0, 1, 0, 1, 0) ),
+    "eqv",
+    (4, 2),
     "binary to multiple decimal",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(10), :to(2) }, digits => [4, 2] ),
-    '~~',
-    [1, 0, 1, 0, 1, 0],
+    convert-base( bases => { :from(10), :to(2) }, digits => (4, 2) ),
+    "eqv",
+    (1, 0, 1, 0, 1, 0),
     "decimal to binary",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(3), :to(16) }, digits => [1, 1, 2, 0] ),
-    '~~',
-    [2, 10],
+    convert-base( bases => { :from(3), :to(16) }, digits => (1, 1, 2, 0) ),
+    "eqv",
+    (2, 10),
     "trinary to hexadecimal",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(16), :to(3) }, digits => [2, 10] ),
-    '~~',
-    [1, 1, 2, 0],
+    convert-base( bases => { :from(16), :to(3) }, digits => (2, 10) ),
+    "eqv",
+    (1, 1, 2, 0),
     "hexadecimal to trinary",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(97), :to(73) }, digits => [3, 46, 60] ),
-    '~~',
-    [6, 10, 45],
+    convert-base( bases => { :from(97), :to(73) }, digits => (3, 46, 60) ),
+    "eqv",
+    (6, 10, 45),
     "15-bit integer",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(2), :to(10) }, digits => [] ),
-    '~~',
-    [0],
+    convert-base( bases => { :from(2), :to(10) }, digits => () ),
+    "eqv",
+    (0,),
     "empty list",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(10), :to(2) }, digits => [0] ),
-    '~~',
-    [0],
+    convert-base( bases => { :from(10), :to(2) }, digits => (0,) ),
+    "eqv",
+    (0,),
     "single zero",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(10), :to(2) }, digits => [0, 0, 0] ),
-    '~~',
-    [0],
+    convert-base( bases => { :from(10), :to(2) }, digits => (0, 0, 0) ),
+    "eqv",
+    (0,),
     "multiple zeros",
 );
 
 cmp-ok(
-    convert-base( bases => { :from(7), :to(10) }, digits => [0, 6, 0] ),
-    '~~',
-    [4, 2],
+    convert-base( bases => { :from(7), :to(10) }, digits => (0, 6, 0) ),
+    "eqv",
+    (4, 2),
     "leading zeros",
 );
 
 dies-ok(
-    { convert-base bases => { :from(1), :to(10) }, digits => [0] },
+    { convert-base bases => { :from(1), :to(10) }, digits => (0,) },
     "input base is one",
 );
 
 dies-ok(
-    { convert-base bases => { :from(0), :to(10) }, digits => [] },
+    { convert-base bases => { :from(0), :to(10) }, digits => () },
     "input base is zero",
 );
 
 dies-ok(
-    { convert-base bases => { :from(-2), :to(10) }, digits => [1] },
+    { convert-base bases => { :from(-2), :to(10) }, digits => (1,) },
     "input base is negative",
 );
 
 dies-ok(
-    { convert-base bases => { :from(2), :to(10) }, digits => [1, -1, 1, 0, 1, 0] },
+    { convert-base bases => { :from(2), :to(10) }, digits => (1, -1, 1, 0, 1, 0) },
     "negative digit",
 );
 
 dies-ok(
-    { convert-base bases => { :from(2), :to(10) }, digits => [1, 2, 1, 0, 1, 0] },
+    { convert-base bases => { :from(2), :to(10) }, digits => (1, 2, 1, 0, 1, 0) },
     "invalid positive digit",
 );
 
 dies-ok(
-    { convert-base bases => { :from(2), :to(1) }, digits => [1, 0, 1, 0, 1, 0] },
+    { convert-base bases => { :from(2), :to(1) }, digits => (1, 0, 1, 0, 1, 0) },
     "output base is one",
 );
 
 dies-ok(
-    { convert-base bases => { :from(10), :to(0) }, digits => [7] },
+    { convert-base bases => { :from(10), :to(0) }, digits => (7,) },
     "output base is zero",
 );
 
 dies-ok(
-    { convert-base bases => { :from(2), :to(-7) }, digits => [1] },
+    { convert-base bases => { :from(2), :to(-7) }, digits => (1,) },
     "output base is negative",
 );
 
 dies-ok(
-    { convert-base bases => { :from(-2), :to(-7) }, digits => [1] },
+    { convert-base bases => { :from(-2), :to(-7) }, digits => (1,) },
     "both bases are negative",
 );
 

--- a/exercises/practice/allergies/.meta/exercise-data.yaml
+++ b/exercises/practice/allergies/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   allergicTo:
     test: |-
       sprintf(q:to/END/, |(%case<input><item score>:p).map(*.raku), %case<expected>, %case<description>.raku);
-      is-deeply(
+      cmp-ok(
           allergic-to( %s, %s ),
+          "eqv",
           %s,
           %s,
       );
@@ -13,7 +14,7 @@ properties:
       sprintf(q:to/END/, %case<input><score>, (if %case<expected> { "<%case<expected>>" } else { 'set()' }), %case<description>.raku);
       cmp-ok(
           list-allergies(%s),
-          &infix:<(==)>,
+          "(==)",
           %s,
           %s,
       );

--- a/exercises/practice/allergies/allergies.rakutest
+++ b/exercises/practice/allergies/allergies.rakutest
@@ -3,312 +3,352 @@ use Test;
 use lib $?FILE.IO.dirname;
 use Allergies;
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("eggs"), :score(0) ),
+    "eqv",
     False,
     "testing for eggs allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("eggs"), :score(1) ),
+    "eqv",
     True,
     "testing for eggs allergy: allergic only to eggs",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("eggs"), :score(3) ),
+    "eqv",
     True,
     "testing for eggs allergy: allergic to eggs and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("eggs"), :score(2) ),
+    "eqv",
     False,
     "testing for eggs allergy: allergic to something, but not eggs",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("eggs"), :score(255) ),
+    "eqv",
     True,
     "testing for eggs allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("peanuts"), :score(0) ),
+    "eqv",
     False,
     "testing for peanuts allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("peanuts"), :score(2) ),
+    "eqv",
     True,
     "testing for peanuts allergy: allergic only to peanuts",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("peanuts"), :score(7) ),
+    "eqv",
     True,
     "testing for peanuts allergy: allergic to peanuts and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("peanuts"), :score(5) ),
+    "eqv",
     False,
     "testing for peanuts allergy: allergic to something, but not peanuts",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("peanuts"), :score(255) ),
+    "eqv",
     True,
     "testing for peanuts allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("shellfish"), :score(0) ),
+    "eqv",
     False,
     "testing for shellfish allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("shellfish"), :score(4) ),
+    "eqv",
     True,
     "testing for shellfish allergy: allergic only to shellfish",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("shellfish"), :score(14) ),
+    "eqv",
     True,
     "testing for shellfish allergy: allergic to shellfish and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("shellfish"), :score(10) ),
+    "eqv",
     False,
     "testing for shellfish allergy: allergic to something, but not shellfish",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("shellfish"), :score(255) ),
+    "eqv",
     True,
     "testing for shellfish allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("strawberries"), :score(0) ),
+    "eqv",
     False,
     "testing for strawberries allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("strawberries"), :score(8) ),
+    "eqv",
     True,
     "testing for strawberries allergy: allergic only to strawberries",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("strawberries"), :score(28) ),
+    "eqv",
     True,
     "testing for strawberries allergy: allergic to strawberries and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("strawberries"), :score(20) ),
+    "eqv",
     False,
     "testing for strawberries allergy: allergic to something, but not strawberries",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("strawberries"), :score(255) ),
+    "eqv",
     True,
     "testing for strawberries allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("tomatoes"), :score(0) ),
+    "eqv",
     False,
     "testing for tomatoes allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("tomatoes"), :score(16) ),
+    "eqv",
     True,
     "testing for tomatoes allergy: allergic only to tomatoes",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("tomatoes"), :score(56) ),
+    "eqv",
     True,
     "testing for tomatoes allergy: allergic to tomatoes and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("tomatoes"), :score(40) ),
+    "eqv",
     False,
     "testing for tomatoes allergy: allergic to something, but not tomatoes",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("tomatoes"), :score(255) ),
+    "eqv",
     True,
     "testing for tomatoes allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("chocolate"), :score(0) ),
+    "eqv",
     False,
     "testing for chocolate allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("chocolate"), :score(32) ),
+    "eqv",
     True,
     "testing for chocolate allergy: allergic only to chocolate",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("chocolate"), :score(112) ),
+    "eqv",
     True,
     "testing for chocolate allergy: allergic to chocolate and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("chocolate"), :score(80) ),
+    "eqv",
     False,
     "testing for chocolate allergy: allergic to something, but not chocolate",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("chocolate"), :score(255) ),
+    "eqv",
     True,
     "testing for chocolate allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("pollen"), :score(0) ),
+    "eqv",
     False,
     "testing for pollen allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("pollen"), :score(64) ),
+    "eqv",
     True,
     "testing for pollen allergy: allergic only to pollen",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("pollen"), :score(224) ),
+    "eqv",
     True,
     "testing for pollen allergy: allergic to pollen and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("pollen"), :score(160) ),
+    "eqv",
     False,
     "testing for pollen allergy: allergic to something, but not pollen",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("pollen"), :score(255) ),
+    "eqv",
     True,
     "testing for pollen allergy: allergic to everything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("cats"), :score(0) ),
+    "eqv",
     False,
     "testing for cats allergy: not allergic to anything",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("cats"), :score(128) ),
+    "eqv",
     True,
     "testing for cats allergy: allergic only to cats",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("cats"), :score(192) ),
+    "eqv",
     True,
     "testing for cats allergy: allergic to cats and something else",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("cats"), :score(64) ),
+    "eqv",
     False,
     "testing for cats allergy: allergic to something, but not cats",
 );
 
-is-deeply(
+cmp-ok(
     allergic-to( :item("cats"), :score(255) ),
+    "eqv",
     True,
     "testing for cats allergy: allergic to everything",
 );
 
 cmp-ok(
     list-allergies(0),
-    &infix:<(==)>,
+    "(==)",
     set(),
     "list when: no allergies",
 );
 
 cmp-ok(
     list-allergies(1),
-    &infix:<(==)>,
+    "(==)",
     <eggs>,
     "list when: just eggs",
 );
 
 cmp-ok(
     list-allergies(2),
-    &infix:<(==)>,
+    "(==)",
     <peanuts>,
     "list when: just peanuts",
 );
 
 cmp-ok(
     list-allergies(8),
-    &infix:<(==)>,
+    "(==)",
     <strawberries>,
     "list when: just strawberries",
 );
 
 cmp-ok(
     list-allergies(3),
-    &infix:<(==)>,
+    "(==)",
     <eggs peanuts>,
     "list when: eggs and peanuts",
 );
 
 cmp-ok(
     list-allergies(5),
-    &infix:<(==)>,
+    "(==)",
     <eggs shellfish>,
     "list when: more than eggs but not peanuts",
 );
 
 cmp-ok(
     list-allergies(248),
-    &infix:<(==)>,
+    "(==)",
     <strawberries tomatoes chocolate pollen cats>,
     "list when: lots of stuff",
 );
 
 cmp-ok(
     list-allergies(255),
-    &infix:<(==)>,
+    "(==)",
     <eggs peanuts shellfish strawberries tomatoes chocolate pollen cats>,
     "list when: everything",
 );
 
 cmp-ok(
     list-allergies(509),
-    &infix:<(==)>,
+    "(==)",
     <eggs shellfish strawberries tomatoes chocolate pollen cats>,
     "list when: no allergen score parts",
 );
 
 cmp-ok(
     list-allergies(257),
-    &infix:<(==)>,
+    "(==)",
     <eggs>,
     "list when: no allergen score parts without highest valid score",
 );

--- a/exercises/practice/armstrong-numbers/.meta/exercise-data.yaml
+++ b/exercises/practice/armstrong-numbers/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   isArmstrongNumber:
     test: |-
       sprintf(q:to/END/, %case<input><number>, %case<expected>, %case<description>.raku);
-      is-deeply(
+      cmp-ok(
           is-armstrong-number(%s),
+          "eqv",
           %s,
           %s,
       );

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.rakutest
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.rakutest
@@ -3,56 +3,65 @@ use Test;
 use lib $?FILE.IO.dirname;
 use ArmstrongNumbers;
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(0),
+    "eqv",
     True,
     "Zero is an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(5),
+    "eqv",
     True,
     "Single-digit numbers are Armstrong numbers",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(10),
+    "eqv",
     False,
     "There are no two-digit Armstrong numbers",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(153),
+    "eqv",
     True,
     "Three-digit number that is an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(100),
+    "eqv",
     False,
     "Three-digit number that is not an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(9474),
+    "eqv",
     True,
     "Four-digit number that is an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(9475),
+    "eqv",
     False,
     "Four-digit number that is not an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(9926315),
+    "eqv",
     True,
     "Seven-digit number that is an Armstrong number",
 );
 
-is-deeply(
+cmp-ok(
     is-armstrong-number(9926314),
+    "eqv",
     False,
     "Seven-digit number that is not an Armstrong number",
 );

--- a/exercises/practice/atbash-cipher/.meta/exercise-data.yaml
+++ b/exercises/practice/atbash-cipher/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   encode:
     test: |-
       sprintf(q:to/END/, (%case<input><phrase>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           encode(%s),
+          "eq",
           %s,
           %s,
       );
@@ -11,8 +12,9 @@ properties:
   decode:
     test: |-
       sprintf(q:to/END/, (%case<input><phrase>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           decode(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/atbash-cipher/atbash-cipher.rakutest
+++ b/exercises/practice/atbash-cipher/atbash-cipher.rakutest
@@ -3,86 +3,100 @@ use Test;
 use lib $?FILE.IO.dirname;
 use AtbashCipher;
 
-is(
+cmp-ok(
     encode("yes"),
+    "eq",
     "bvh",
     "encode: encode yes",
 );
 
-is(
+cmp-ok(
     encode("no"),
+    "eq",
     "ml",
     "encode: encode no",
 );
 
-is(
+cmp-ok(
     encode("OMG"),
+    "eq",
     "lnt",
     "encode: encode OMG",
 );
 
-is(
+cmp-ok(
     encode("O M G"),
+    "eq",
     "lnt",
     "encode: encode spaces",
 );
 
-is(
+cmp-ok(
     encode("mindblowingly"),
+    "eq",
     "nrmwy oldrm tob",
     "encode: encode mindblowingly",
 );
 
-is(
+cmp-ok(
     encode("Testing,1 2 3, testing."),
+    "eq",
     "gvhgr mt123 gvhgr mt",
     "encode: encode numbers",
 );
 
-is(
+cmp-ok(
     encode("Truth is fiction."),
+    "eq",
     "gifgs rhurx grlm",
     "encode: encode deep thought",
 );
 
-is(
+cmp-ok(
     encode("The quick brown fox jumps over the lazy dog."),
+    "eq",
     "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt",
     "encode: encode all the letters",
 );
 
-is(
+cmp-ok(
     decode("vcvix rhn"),
+    "eq",
     "exercism",
     "decode: decode exercism",
 );
 
-is(
+cmp-ok(
     decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"),
+    "eq",
     "anobstacleisoftenasteppingstone",
     "decode: decode a sentence",
 );
 
-is(
+cmp-ok(
     decode("gvhgr mt123 gvhgr mt"),
+    "eq",
     "testing123testing",
     "decode: decode numbers",
 );
 
-is(
+cmp-ok(
     decode("gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"),
+    "eq",
     "thequickbrownfoxjumpsoverthelazydog",
     "decode: decode all the letters",
 );
 
-is(
+cmp-ok(
     decode("vc vix    r hn"),
+    "eq",
     "exercism",
     "decode: decode with too many spaces",
 );
 
-is(
+cmp-ok(
     decode("zmlyhgzxovrhlugvmzhgvkkrmthglmv"),
+    "eq",
     "anobstacleisoftenasteppingstone",
     "decode: decode with no spaces",
 );

--- a/exercises/practice/beer-song/.meta/exercise-data.yaml
+++ b/exercises/practice/beer-song/.meta/exercise-data.yaml
@@ -4,8 +4,9 @@ properties:
   recite:
     test: |-
       sprintf(q:to/END/, |(<bottles verses> Z=> %case<input><startBottles takeDown>).map(*.raku), %case<expected>.join("\n").trim, %case<description>.raku);
-      is(
+      cmp-ok(
           sing( %s, %s ),
+          "eq",
           q:to/SONG/.trim,
       %s
       SONG

--- a/exercises/practice/beer-song/beer-song.rakutest
+++ b/exercises/practice/beer-song/beer-song.rakutest
@@ -3,8 +3,9 @@ use Test;
 use lib $?FILE.IO.dirname;
 use BeerSong;
 
-is(
+cmp-ok(
     sing( :bottles(99), :verses(1) ),
+    "eq",
     q:to/SONG/.trim,
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
@@ -12,8 +13,9 @@ SONG
     "verse: single verse: first generic verse",
 );
 
-is(
+cmp-ok(
     sing( :bottles(3), :verses(1) ),
+    "eq",
     q:to/SONG/.trim,
 3 bottles of beer on the wall, 3 bottles of beer.
 Take one down and pass it around, 2 bottles of beer on the wall.
@@ -21,8 +23,9 @@ SONG
     "verse: single verse: last generic verse",
 );
 
-is(
+cmp-ok(
     sing( :bottles(2), :verses(1) ),
+    "eq",
     q:to/SONG/.trim,
 2 bottles of beer on the wall, 2 bottles of beer.
 Take one down and pass it around, 1 bottle of beer on the wall.
@@ -30,8 +33,9 @@ SONG
     "verse: single verse: verse with 2 bottles",
 );
 
-is(
+cmp-ok(
     sing( :bottles(1), :verses(1) ),
+    "eq",
     q:to/SONG/.trim,
 1 bottle of beer on the wall, 1 bottle of beer.
 Take it down and pass it around, no more bottles of beer on the wall.
@@ -39,8 +43,9 @@ SONG
     "verse: single verse: verse with 1 bottle",
 );
 
-is(
+cmp-ok(
     sing( :bottles(0), :verses(1) ),
+    "eq",
     q:to/SONG/.trim,
 No more bottles of beer on the wall, no more bottles of beer.
 Go to the store and buy some more, 99 bottles of beer on the wall.
@@ -48,8 +53,9 @@ SONG
     "verse: single verse: verse with 0 bottles",
 );
 
-is(
+cmp-ok(
     sing( :bottles(99), :verses(2) ),
+    "eq",
     q:to/SONG/.trim,
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.
@@ -60,8 +66,9 @@ SONG
     "lyrics: multiple verses: first two verses",
 );
 
-is(
+cmp-ok(
     sing( :bottles(2), :verses(3) ),
+    "eq",
     q:to/SONG/.trim,
 2 bottles of beer on the wall, 2 bottles of beer.
 Take one down and pass it around, 1 bottle of beer on the wall.
@@ -75,8 +82,9 @@ SONG
     "lyrics: multiple verses: last three verses",
 );
 
-is(
+cmp-ok(
     sing( :bottles(99), :verses(100) ),
+    "eq",
     q:to/SONG/.trim,
 99 bottles of beer on the wall, 99 bottles of beer.
 Take one down and pass it around, 98 bottles of beer on the wall.

--- a/exercises/practice/bob/.meta/exercise-data.yaml
+++ b/exercises/practice/bob/.meta/exercise-data.yaml
@@ -3,8 +3,9 @@ properties:
   response:
     test: |-
       sprintf(q:to/END/, (%case<input><heyBob>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           Bob.hey(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/bob/bob.rakutest
+++ b/exercises/practice/bob/bob.rakutest
@@ -9,152 +9,177 @@ for <hey> -> $method {
   Bob.^can($method) or bail-out "Cannot run expected method `$method`.";
 }
 
-is(
+cmp-ok(
     Bob.hey("Tom-ay-to, tom-aaaah-to."),
+    "eq",
     "Whatever.",
     "stating something",
 );
 
-is(
+cmp-ok(
     Bob.hey("WATCH OUT!"),
+    "eq",
     "Whoa, chill out!",
     "shouting",
 );
 
-is(
+cmp-ok(
     Bob.hey("FCECDFCAAB"),
+    "eq",
     "Whoa, chill out!",
     "shouting gibberish",
 );
 
-is(
+cmp-ok(
     Bob.hey("Does this cryogenic chamber make me look fat?"),
+    "eq",
     "Sure.",
     "asking a question",
 );
 
-is(
+cmp-ok(
     Bob.hey("You are, what, like 15?"),
+    "eq",
     "Sure.",
     "asking a numeric question",
 );
 
-is(
+cmp-ok(
     Bob.hey("fffbbcbeab?"),
+    "eq",
     "Sure.",
     "asking gibberish",
 );
 
-is(
+cmp-ok(
     Bob.hey("Hi there!"),
+    "eq",
     "Whatever.",
     "talking forcefully",
 );
 
-is(
+cmp-ok(
     Bob.hey("It's OK if you don't want to go work for NASA."),
+    "eq",
     "Whatever.",
     "using acronyms in regular speech",
 );
 
-is(
+cmp-ok(
     Bob.hey("WHAT'S GOING ON?"),
+    "eq",
     "Calm down, I know what I'm doing!",
     "forceful question",
 );
 
-is(
+cmp-ok(
     Bob.hey("1, 2, 3 GO!"),
+    "eq",
     "Whoa, chill out!",
     "shouting numbers",
 );
 
-is(
+cmp-ok(
     Bob.hey("1, 2, 3"),
+    "eq",
     "Whatever.",
     "no letters",
 );
 
-is(
+cmp-ok(
     Bob.hey("4?"),
+    "eq",
     "Sure.",
     "question with no letters",
 );
 
-is(
+cmp-ok(
     Bob.hey("ZOMG THE \%^*\@#\$(*^ ZOMBIES ARE COMING!!11!!1!"),
+    "eq",
     "Whoa, chill out!",
     "shouting with special characters",
 );
 
-is(
+cmp-ok(
     Bob.hey("I HATE THE DENTIST"),
+    "eq",
     "Whoa, chill out!",
     "shouting with no exclamation mark",
 );
 
-is(
+cmp-ok(
     Bob.hey("Ending with ? means a question."),
+    "eq",
     "Whatever.",
     "statement containing question mark",
 );
 
-is(
+cmp-ok(
     Bob.hey(":) ?"),
+    "eq",
     "Sure.",
     "non-letters with question",
 );
 
-is(
+cmp-ok(
     Bob.hey("Wait! Hang on. Are you going to be OK?"),
+    "eq",
     "Sure.",
     "prattling on",
 );
 
-is(
+cmp-ok(
     Bob.hey(""),
+    "eq",
     "Fine. Be that way!",
     "silence",
 );
 
-is(
+cmp-ok(
     Bob.hey("          "),
+    "eq",
     "Fine. Be that way!",
     "prolonged silence",
 );
 
-is(
+cmp-ok(
     Bob.hey("\t\t\t\t\t\t\t\t\t\t"),
+    "eq",
     "Fine. Be that way!",
     "alternate silence",
 );
 
-is(
+cmp-ok(
     Bob.hey("\nDoes this cryogenic chamber make me look fat?\nNo."),
+    "eq",
     "Whatever.",
     "multiple line question",
 );
 
-is(
+cmp-ok(
     Bob.hey("         hmmmmmmm..."),
+    "eq",
     "Whatever.",
     "starting with whitespace",
 );
 
-is(
+cmp-ok(
     Bob.hey("Okay if like my  spacebar  quite a bit?   "),
+    "eq",
     "Sure.",
     "ending with whitespace",
 );
 
-is(
+cmp-ok(
     Bob.hey("\n\r \t"),
+    "eq",
     "Fine. Be that way!",
     "other whitespace",
 );
 
-is(
+cmp-ok(
     Bob.hey("This is a statement ending with whitespace      "),
+    "eq",
     "Whatever.",
     "non-question ending with whitespace",
 );

--- a/exercises/practice/clock/.meta/exercise-data.yaml
+++ b/exercises/practice/clock/.meta/exercise-data.yaml
@@ -3,8 +3,9 @@ properties:
   create:
     test: |-
       sprintf(q:to/END/, (|(%case<input><hour minute>:p), |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           Clock.new( %s, %s ).time,
+          "eq",
           %s,
           %s,
       );
@@ -12,8 +13,9 @@ properties:
   add:
     test: |-
       sprintf(q:to/END/, (|(%case<input><hour minute>:p), :minutes(%case<input><value>), |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           Clock.new( %s, %s ).add( %s ).time,
+          "eq",
           %s,
           %s,
       );
@@ -21,8 +23,9 @@ properties:
   subtract:
     test: |-
       sprintf(q:to/END/, (|(%case<input><hour minute>:p), :minutes(%case<input><value>), |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           Clock.new( %s, %s ).subtract( %s ).time,
+          "eq",
           %s,
           %s,
       );
@@ -31,8 +34,9 @@ properties:
     test: |-
       if %case<expected> {
           sprintf(q:to/END/, (|%case<input><clock1 clock2>.map({|(.<hour minute>:p)}), %case<description>).map(*.raku));
-          is-deeply(
+          cmp-ok(
               Clock.new( %s, %s ),
+              "eqv",
               Clock.new( %s, %s ),
               %s,
           );

--- a/exercises/practice/clock/clock.rakutest
+++ b/exercises/practice/clock/clock.rakutest
@@ -7,224 +7,261 @@ for <time add subtract> -> $method {
   Clock.^can($method) or bail-out "Cannot run expected method `$method`.";
 }
 
-is(
+cmp-ok(
     Clock.new( :hour(8), :minute(0) ).time,
+    "eq",
     "08:00",
     "Create a new clock with an initial time: on the hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(11), :minute(9) ).time,
+    "eq",
     "11:09",
     "Create a new clock with an initial time: past the hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(24), :minute(0) ).time,
+    "eq",
     "00:00",
     "Create a new clock with an initial time: midnight is zero hours",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(25), :minute(0) ).time,
+    "eq",
     "01:00",
     "Create a new clock with an initial time: hour rolls over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(100), :minute(0) ).time,
+    "eq",
     "04:00",
     "Create a new clock with an initial time: hour rolls over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(1), :minute(60) ).time,
+    "eq",
     "02:00",
     "Create a new clock with an initial time: sixty minutes is next hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(160) ).time,
+    "eq",
     "02:40",
     "Create a new clock with an initial time: minutes roll over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(1723) ).time,
+    "eq",
     "04:43",
     "Create a new clock with an initial time: minutes roll over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(25), :minute(160) ).time,
+    "eq",
     "03:40",
     "Create a new clock with an initial time: hour and minutes roll over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(201), :minute(3001) ).time,
+    "eq",
     "11:01",
     "Create a new clock with an initial time: hour and minutes roll over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(72), :minute(8640) ).time,
+    "eq",
     "00:00",
     "Create a new clock with an initial time: hour and minutes roll over to exactly midnight",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(-1), :minute(15) ).time,
+    "eq",
     "23:15",
     "Create a new clock with an initial time: negative hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(-25), :minute(0) ).time,
+    "eq",
     "23:00",
     "Create a new clock with an initial time: negative hour rolls over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(-91), :minute(0) ).time,
+    "eq",
     "05:00",
     "Create a new clock with an initial time: negative hour rolls over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(1), :minute(-40) ).time,
+    "eq",
     "00:20",
     "Create a new clock with an initial time: negative minutes",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(1), :minute(-160) ).time,
+    "eq",
     "22:20",
     "Create a new clock with an initial time: negative minutes roll over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(1), :minute(-4820) ).time,
+    "eq",
     "16:40",
     "Create a new clock with an initial time: negative minutes roll over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(2), :minute(-60) ).time,
+    "eq",
     "01:00",
     "Create a new clock with an initial time: negative sixty minutes is previous hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(-25), :minute(-160) ).time,
+    "eq",
     "20:20",
     "Create a new clock with an initial time: negative hour and minutes both roll over",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(-121), :minute(-5810) ).time,
+    "eq",
     "22:10",
     "Create a new clock with an initial time: negative hour and minutes both roll over continuously",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(10), :minute(0) ).add( :minutes(3) ).time,
+    "eq",
     "10:03",
     "Add minutes: add minutes",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(6), :minute(41) ).add( :minutes(0) ).time,
+    "eq",
     "06:41",
     "Add minutes: add no minutes",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(45) ).add( :minutes(40) ).time,
+    "eq",
     "01:25",
     "Add minutes: add to next hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(10), :minute(0) ).add( :minutes(61) ).time,
+    "eq",
     "11:01",
     "Add minutes: add more than one hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(45) ).add( :minutes(160) ).time,
+    "eq",
     "03:25",
     "Add minutes: add more than two hours with carry",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(23), :minute(59) ).add( :minutes(2) ).time,
+    "eq",
     "00:01",
     "Add minutes: add across midnight",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(5), :minute(32) ).add( :minutes(1500) ).time,
+    "eq",
     "06:32",
     "Add minutes: add more than one day (1500 min = 25 hrs)",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(1), :minute(1) ).add( :minutes(3500) ).time,
+    "eq",
     "11:21",
     "Add minutes: add more than two days",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(10), :minute(3) ).subtract( :minutes(3) ).time,
+    "eq",
     "10:00",
     "Subtract minutes: subtract minutes",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(10), :minute(3) ).subtract( :minutes(30) ).time,
+    "eq",
     "09:33",
     "Subtract minutes: subtract to previous hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(10), :minute(3) ).subtract( :minutes(70) ).time,
+    "eq",
     "08:53",
     "Subtract minutes: subtract more than an hour",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(3) ).subtract( :minutes(4) ).time,
+    "eq",
     "23:59",
     "Subtract minutes: subtract across midnight",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(0), :minute(0) ).subtract( :minutes(160) ).time,
+    "eq",
     "21:20",
     "Subtract minutes: subtract more than two hours",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(6), :minute(15) ).subtract( :minutes(160) ).time,
+    "eq",
     "03:35",
     "Subtract minutes: subtract more than two hours with borrow",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(5), :minute(32) ).subtract( :minutes(1500) ).time,
+    "eq",
     "04:32",
     "Subtract minutes: subtract more than one day (1500 min = 25 hrs)",
 );
 
-is(
+cmp-ok(
     Clock.new( :hour(2), :minute(20) ).subtract( :minutes(3000) ).time,
+    "eq",
     "00:20",
     "Subtract minutes: subtract more than two days",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(15), :minute(37) ),
+    "eqv",
     Clock.new( :hour(15), :minute(37) ),
     "Compare two clocks for equality: clocks with same time",
 );
@@ -243,80 +280,93 @@ cmp-ok(
     "Compare two clocks for equality: clocks an hour apart",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(10), :minute(37) ),
+    "eqv",
     Clock.new( :hour(34), :minute(37) ),
     "Compare two clocks for equality: clocks with hour overflow",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(3), :minute(11) ),
+    "eqv",
     Clock.new( :hour(99), :minute(11) ),
     "Compare two clocks for equality: clocks with hour overflow by several days",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(22), :minute(40) ),
+    "eqv",
     Clock.new( :hour(-2), :minute(40) ),
     "Compare two clocks for equality: clocks with negative hour",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(17), :minute(3) ),
+    "eqv",
     Clock.new( :hour(-31), :minute(3) ),
     "Compare two clocks for equality: clocks with negative hour that wraps",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(13), :minute(49) ),
+    "eqv",
     Clock.new( :hour(-83), :minute(49) ),
     "Compare two clocks for equality: clocks with negative hour that wraps multiple times",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(0), :minute(1) ),
+    "eqv",
     Clock.new( :hour(0), :minute(1441) ),
     "Compare two clocks for equality: clocks with minute overflow",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(2), :minute(2) ),
+    "eqv",
     Clock.new( :hour(2), :minute(4322) ),
     "Compare two clocks for equality: clocks with minute overflow by several days",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(2), :minute(40) ),
+    "eqv",
     Clock.new( :hour(3), :minute(-20) ),
     "Compare two clocks for equality: clocks with negative minute",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(4), :minute(10) ),
+    "eqv",
     Clock.new( :hour(5), :minute(-1490) ),
     "Compare two clocks for equality: clocks with negative minute that wraps",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(6), :minute(15) ),
+    "eqv",
     Clock.new( :hour(6), :minute(-4305) ),
     "Compare two clocks for equality: clocks with negative minute that wraps multiple times",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(7), :minute(32) ),
+    "eqv",
     Clock.new( :hour(-12), :minute(-268) ),
     "Compare two clocks for equality: clocks with negative hours and minutes",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(18), :minute(7) ),
+    "eqv",
     Clock.new( :hour(-54), :minute(-11513) ),
     "Compare two clocks for equality: clocks with negative hours and minutes that wrap",
 );
 
-is-deeply(
+cmp-ok(
     Clock.new( :hour(24), :minute(0) ),
+    "eqv",
     Clock.new( :hour(0), :minute(0) ),
     "Compare two clocks for equality: full clock and zeroed clock",
 );

--- a/exercises/practice/collatz-conjecture/.meta/exercise-data.yaml
+++ b/exercises/practice/collatz-conjecture/.meta/exercise-data.yaml
@@ -13,7 +13,7 @@ properties:
           sprintf(q:to/END/, %case<input><number>, |(%case<expected description>.map(*.raku)));
           cmp-ok(
               collatz-conjecture(%s),
-              &infix:<==>,
+              "==",
               %s,
               %s,
           );

--- a/exercises/practice/collatz-conjecture/collatz-conjecture.rakutest
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture.rakutest
@@ -5,28 +5,28 @@ use CollatzConjecture;
 
 cmp-ok(
     collatz-conjecture(1),
-    &infix:<==>,
+    "==",
     0,
     "zero steps for one",
 );
 
 cmp-ok(
     collatz-conjecture(16),
-    &infix:<==>,
+    "==",
     4,
     "divide if even",
 );
 
 cmp-ok(
     collatz-conjecture(12),
-    &infix:<==>,
+    "==",
     9,
     "even and odd steps",
 );
 
 cmp-ok(
     collatz-conjecture(1000000),
-    &infix:<==>,
+    "==",
     152,
     "large number of even and odd steps",
 );

--- a/exercises/practice/crypto-square/.meta/exercise-data.yaml
+++ b/exercises/practice/crypto-square/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   ciphertext:
     test: |-
       sprintf(q:to/END/, (%case<input><plaintext>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           crypto-square(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/crypto-square/crypto-square.rakutest
+++ b/exercises/practice/crypto-square/crypto-square.rakutest
@@ -3,44 +3,51 @@ use Test;
 use lib $?FILE.IO.dirname;
 use CryptoSquare;
 
-is(
+cmp-ok(
     crypto-square(""),
+    "eq",
     "",
     "empty plaintext results in an empty ciphertext",
 );
 
-is(
+cmp-ok(
     crypto-square("A"),
+    "eq",
     "a",
     "Lowercase",
 );
 
-is(
+cmp-ok(
     crypto-square("  b "),
+    "eq",
     "b",
     "Remove spaces",
 );
 
-is(
+cmp-ok(
     crypto-square("\@1,\%!"),
+    "eq",
     "1",
     "Remove punctuation",
 );
 
-is(
+cmp-ok(
     crypto-square("This is fun!"),
+    "eq",
     "tsf hiu isn",
     "9 character plaintext results in 3 chunks of 3 characters",
 );
 
-is(
+cmp-ok(
     crypto-square("Chill out."),
+    "eq",
     "clu hlt io ",
     "8 character plaintext results in 3 chunks, the last one with a trailing space",
 );
 
-is(
+cmp-ok(
     crypto-square("If man was meant to stay on the ground, god would have given us roots."),
+    "eq",
     "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ",
     "54 character plaintext results in 7 chunks, the last two with trailing spaces",
 );

--- a/exercises/practice/difference-of-squares/.meta/exercise-data.yaml
+++ b/exercises/practice/difference-of-squares/.meta/exercise-data.yaml
@@ -4,7 +4,7 @@ properties:
       sprintf(q:to/END/, %case<input><number>, %case<expected>, %case<description>.raku);
       cmp-ok(
           difference-of-squares(%s),
-          &infix:<==>,
+          "==",
           %s,
           %s,
       );
@@ -14,7 +14,7 @@ properties:
       sprintf(q:to/END/, %case<input><number>, %case<expected>, %case<description>.raku);
       cmp-ok(
           sum-of-squares(%s),
-          &infix:<==>,
+          "==",
           %s,
           %s,
       );
@@ -24,7 +24,7 @@ properties:
       sprintf(q:to/END/, %case<input><number>, %case<expected>, %case<description>.raku);
       cmp-ok(
           square-of-sum(%s),
-          &infix:<==>,
+          "==",
           %s,
           %s,
       );

--- a/exercises/practice/difference-of-squares/difference-of-squares.rakutest
+++ b/exercises/practice/difference-of-squares/difference-of-squares.rakutest
@@ -5,63 +5,63 @@ use DifferenceOfSquares;
 
 cmp-ok(
     square-of-sum(1),
-    &infix:<==>,
+    "==",
     1,
     "Square the sum of the numbers up to the given number: square of sum 1",
 );
 
 cmp-ok(
     square-of-sum(5),
-    &infix:<==>,
+    "==",
     225,
     "Square the sum of the numbers up to the given number: square of sum 5",
 );
 
 cmp-ok(
     square-of-sum(100),
-    &infix:<==>,
+    "==",
     25502500,
     "Square the sum of the numbers up to the given number: square of sum 100",
 );
 
 cmp-ok(
     sum-of-squares(1),
-    &infix:<==>,
+    "==",
     1,
     "Sum the squares of the numbers up to the given number: sum of squares 1",
 );
 
 cmp-ok(
     sum-of-squares(5),
-    &infix:<==>,
+    "==",
     55,
     "Sum the squares of the numbers up to the given number: sum of squares 5",
 );
 
 cmp-ok(
     sum-of-squares(100),
-    &infix:<==>,
+    "==",
     338350,
     "Sum the squares of the numbers up to the given number: sum of squares 100",
 );
 
 cmp-ok(
     difference-of-squares(1),
-    &infix:<==>,
+    "==",
     0,
     "Subtract sum of squares from square of sums: difference of squares 1",
 );
 
 cmp-ok(
     difference-of-squares(5),
-    &infix:<==>,
+    "==",
     170,
     "Subtract sum of squares from square of sums: difference of squares 5",
 );
 
 cmp-ok(
     difference-of-squares(100),
-    &infix:<==>,
+    "==",
     25164150,
     "Subtract sum of squares from square of sums: difference of squares 100",
 );

--- a/exercises/practice/flatten-array/.meta/exercise-data.yaml
+++ b/exercises/practice/flatten-array/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   flatten:
     test: |-
       sprintf(q:to/END/, (%case<input><array>.deepmap({$_ eqv Any ?? Nil !! $_})<>, %case<expected><>, %case<description>).map(*.raku));
-      is-deeply(
+      cmp-ok(
           flatten-array(%s),
+          "eqv",
           %s,
           %s,
       );

--- a/exercises/practice/flatten-array/flatten-array.rakutest
+++ b/exercises/practice/flatten-array/flatten-array.rakutest
@@ -3,68 +3,79 @@ use Test;
 use lib $?FILE.IO.dirname;
 use FlattenArray;
 
-is-deeply(
+cmp-ok(
     flatten-array([]),
+    "eqv",
     [],
     "empty",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([0, 1, 2]),
+    "eqv",
     [0, 1, 2],
     "no nesting",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([[[],],]),
+    "eqv",
     [],
     "flattens a nested array",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([1, [2, 3, 4, 5, 6, 7], 8]),
+    "eqv",
     [1, 2, 3, 4, 5, 6, 7, 8],
     "flattens array with just integers present",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([0, 2, [[2, 3], 8, 100, 4, [[[50],],]], -2]),
+    "eqv",
     [0, 2, 2, 3, 8, 100, 4, 50, -2],
     "5 level nesting",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([1, [2, [[3],], [4, [[5],]], 6, 7], 8]),
+    "eqv",
     [1, 2, 3, 4, 5, 6, 7, 8],
     "6 level nesting",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([1, 2, Nil]),
+    "eqv",
     [1, 2],
     "null values are omitted from the final result",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([Nil, Nil, 3]),
+    "eqv",
     [3],
     "consecutive null values at the front of the list are omitted from the final result",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([1, Nil, Nil, 4]),
+    "eqv",
     [1, 4],
     "consecutive null values in the middle of the list are omitted from the final result",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([0, 2, [[2, 3], 8, [[100],], Nil, [[Nil],]], -2]),
+    "eqv",
     [0, 2, 2, 3, 8, 100, -2],
     "6 level nest list with null values",
 );
 
-is-deeply(
+cmp-ok(
     flatten-array([Nil, [[[Nil],],], Nil, Nil, [[Nil, Nil], Nil], Nil]),
+    "eqv",
     [],
     "all values in nested list are null",
 );

--- a/exercises/practice/grade-school/.meta/exercise-data.yaml
+++ b/exercises/practice/grade-school/.meta/exercise-data.yaml
@@ -6,9 +6,10 @@ properties:
     test: |-
       '$grade-school.=new;' ~ "\n" ~
       sprintf(q:to/END/, ([~] do for @(%case<input><students>) { "\n" ~ '        $grade-school.add( ' ~ ":student({$_[0].raku}), :grade({$_[1].raku})" ~ ' ),' }), %case<expected>.List.raku, %case<description>.raku)
-      is-deeply(
+      cmp-ok(
           (%s
           ),
+          "eqv",
           %s,
           %s,
       );
@@ -19,8 +20,9 @@ properties:
       '$grade-school.=new;' ~
       sprintf(q:to/END/, ([~] do for @(%case<input><students>) { "\n" ~ '$grade-school.add( ' ~ ":student({$_[0].raku}), :grade({$_[1].raku})" ~ ' );' }), %case<expected>.List.raku, %case<description>.raku)
       %s
-      is-deeply(
+      cmp-ok(
           $grade-school.roster,
+          "eqv",
           %s,
           %s,
       );
@@ -31,8 +33,9 @@ properties:
       '$grade-school.=new;' ~
       sprintf(q:to/END/, ([~] do for @(%case<input><students>) { "\n" ~ '$grade-school.add( ' ~ ":student({$_[0].raku}), :grade({$_[1].raku})" ~ ' );' }), %case<input><desiredGrade>, %case<expected>.List.raku, %case<description>.raku)
       %s
-      is-deeply(
+      cmp-ok(
           $grade-school.roster( :grade(%s) ),
+          "eqv",
           %s,
           %s,
       );

--- a/exercises/practice/grade-school/grade-school.rakutest
+++ b/exercises/practice/grade-school/grade-school.rakutest
@@ -10,36 +10,40 @@ for <add roster> -> $method {
 my GradeSchool $grade-school;
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     (),
     "Roster is empty when no student is added",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     (
         $grade-school.add( :student("Aimee"), :grade(2) ),
     ),
+    "eqv",
     (Bool::True,),
     "Add a student",
 );
 
 $grade-school.=new;
 $grade-school.add( :student("Aimee"), :grade(2) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Aimee",),
     "Student is added to the roster",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     (
         $grade-school.add( :student("Blair"), :grade(2) ),
         $grade-school.add( :student("James"), :grade(2) ),
         $grade-school.add( :student("Paul"), :grade(2) ),
     ),
+    "eqv",
     (Bool::True, Bool::True, Bool::True),
     "Adding multiple students in the same grade in the roster",
 );
@@ -48,20 +52,22 @@ $grade-school.=new;
 $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("Paul"), :grade(2) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Blair", "James", "Paul"),
     "Multiple students in the same grade are added to the roster",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     (
         $grade-school.add( :student("Blair"), :grade(2) ),
         $grade-school.add( :student("James"), :grade(2) ),
         $grade-school.add( :student("James"), :grade(2) ),
         $grade-school.add( :student("Paul"), :grade(2) ),
     ),
+    "eqv",
     (Bool::True, Bool::True, Bool::False, Bool::True),
     "Cannot add student to same grade in the roster more than once",
 );
@@ -71,18 +77,20 @@ $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("Paul"), :grade(2) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Blair", "James", "Paul"),
     "Student not added to same grade in the roster more than once",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     (
         $grade-school.add( :student("Chelsea"), :grade(3) ),
         $grade-school.add( :student("Logan"), :grade(7) ),
     ),
+    "eqv",
     (Bool::True, Bool::True),
     "Adding students in multiple grades",
 );
@@ -90,20 +98,22 @@ is-deeply(
 $grade-school.=new;
 $grade-school.add( :student("Chelsea"), :grade(3) );
 $grade-school.add( :student("Logan"), :grade(7) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Chelsea", "Logan"),
     "Students in multiple grades are added to the roster",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     (
         $grade-school.add( :student("Blair"), :grade(2) ),
         $grade-school.add( :student("James"), :grade(2) ),
         $grade-school.add( :student("James"), :grade(3) ),
         $grade-school.add( :student("Paul"), :grade(3) ),
     ),
+    "eqv",
     (Bool::True, Bool::True, Bool::False, Bool::True),
     "Cannot add same student to multiple grades in the roster",
 );
@@ -113,8 +123,9 @@ $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("James"), :grade(3) );
 $grade-school.add( :student("Paul"), :grade(3) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Blair", "James", "Paul"),
     "Student not added to multiple grades in the roster",
 );
@@ -123,8 +134,9 @@ $grade-school.=new;
 $grade-school.add( :student("Jim"), :grade(3) );
 $grade-school.add( :student("Peter"), :grade(2) );
 $grade-school.add( :student("Anna"), :grade(1) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Anna", "Peter", "Jim"),
     "Students are sorted by grades in the roster",
 );
@@ -133,8 +145,9 @@ $grade-school.=new;
 $grade-school.add( :student("Peter"), :grade(2) );
 $grade-school.add( :student("Zoe"), :grade(2) );
 $grade-school.add( :student("Alex"), :grade(2) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Alex", "Peter", "Zoe"),
     "Students are sorted by name in the roster",
 );
@@ -147,15 +160,17 @@ $grade-school.add( :student("Zoe"), :grade(2) );
 $grade-school.add( :student("Alex"), :grade(2) );
 $grade-school.add( :student("Jim"), :grade(3) );
 $grade-school.add( :student("Charlie"), :grade(1) );
-is-deeply(
+cmp-ok(
     $grade-school.roster,
+    "eqv",
     ("Anna", "Barb", "Charlie", "Alex", "Peter", "Zoe", "Jim"),
     "Students are sorted by grades and then by name in the roster",
 );
 
 $grade-school.=new;
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(1) ),
+    "eqv",
     (),
     "Grade is empty if no students in the roster",
 );
@@ -165,8 +180,9 @@ $grade-school.add( :student("Peter"), :grade(2) );
 $grade-school.add( :student("Zoe"), :grade(2) );
 $grade-school.add( :student("Alex"), :grade(2) );
 $grade-school.add( :student("Jim"), :grade(3) );
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(1) ),
+    "eqv",
     (),
     "Grade is empty if no students in that grade",
 );
@@ -176,8 +192,9 @@ $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("Paul"), :grade(2) );
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(2) ),
+    "eqv",
     ("Blair", "James", "Paul"),
     "Student not added to same grade more than once",
 );
@@ -187,8 +204,9 @@ $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("James"), :grade(3) );
 $grade-school.add( :student("Paul"), :grade(3) );
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(2) ),
+    "eqv",
     ("Blair", "James"),
     "Student not added to multiple grades",
 );
@@ -198,8 +216,9 @@ $grade-school.add( :student("Blair"), :grade(2) );
 $grade-school.add( :student("James"), :grade(2) );
 $grade-school.add( :student("James"), :grade(3) );
 $grade-school.add( :student("Paul"), :grade(3) );
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(3) ),
+    "eqv",
     ("Paul",),
     "Student not added to other grade for multiple grades",
 );
@@ -208,8 +227,9 @@ $grade-school.=new;
 $grade-school.add( :student("Franklin"), :grade(5) );
 $grade-school.add( :student("Bradley"), :grade(5) );
 $grade-school.add( :student("Jeff"), :grade(1) );
-is-deeply(
+cmp-ok(
     $grade-school.roster( :grade(5) ),
+    "eqv",
     ("Bradley", "Franklin"),
     "Students are sorted by name in a grade",
 );

--- a/exercises/practice/hello-world/.meta/exercise-data.yaml
+++ b/exercises/practice/hello-world/.meta/exercise-data.yaml
@@ -1,10 +1,11 @@
 plan: 1
 tests: |-
-  # Run the 'is' subroutine from the 'Test' module, with three arguments.
-  is(
-    hello,           # Run the 'hello' subroutine, which is imported from your module.
-    'Hello, World!', # The expected result to compare with 'hello'.
-    'Say Hi!'        # The test description.
+  # Run the 'cmp-ok' subroutine from the 'Test' module, with four arguments.
+  cmp-ok(
+      hello,           # Run the 'hello' subroutine, which is imported from your module.
+      'eq',            # The comparison we're using ('eq' for comparing strings).
+      'Hello, World!', # The expected result to compare with 'hello'.
+      'Say Hi!'        # The test description.
   );
 
 lib_comment: Look for the module inside the same directory as this test file.
@@ -13,8 +14,8 @@ plan_comment: This is how many tests we expect to run.
 unit: module
 unit_comment: |-
   #`(
-    This is a 'stub' file. It's a little start on your solution.
-    It is not a complete solution though; you will have to write some code.
+      This is a 'stub' file. It's a little start on your solution.
+      It is not a complete solution though; you will have to write some code.
   )
 example: |-
   sub hello is export {

--- a/exercises/practice/hello-world/.meta/solutions/HelloWorld.rakumod
+++ b/exercises/practice/hello-world/.meta/solutions/HelloWorld.rakumod
@@ -1,6 +1,6 @@
 #`(
-  This is a 'stub' file. It's a little start on your solution.
-  It is not a complete solution though; you will have to write some code.
+    This is a 'stub' file. It's a little start on your solution.
+    It is not a complete solution though; you will have to write some code.
 )
 unit module HelloWorld;
 

--- a/exercises/practice/hello-world/HelloWorld.rakumod
+++ b/exercises/practice/hello-world/HelloWorld.rakumod
@@ -1,6 +1,6 @@
 #`(
-  This is a 'stub' file. It's a little start on your solution.
-  It is not a complete solution though; you will have to write some code.
+    This is a 'stub' file. It's a little start on your solution.
+    It is not a complete solution though; you will have to write some code.
 )
 unit module HelloWorld;
 

--- a/exercises/practice/hello-world/hello-world.rakutest
+++ b/exercises/practice/hello-world/hello-world.rakutest
@@ -4,9 +4,10 @@ use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as t
 use HelloWorld;
 plan 1; #`[This is how many tests we expect to run.]
 
-# Run the 'is' subroutine from the 'Test' module, with three arguments.
-is(
-  hello,           # Run the 'hello' subroutine, which is imported from your module.
-  'Hello, World!', # The expected result to compare with 'hello'.
-  'Say Hi!'        # The test description.
+# Run the 'cmp-ok' subroutine from the 'Test' module, with four arguments.
+cmp-ok(
+    hello,           # Run the 'hello' subroutine, which is imported from your module.
+    'eq',            # The comparison we're using ('eq' for comparing strings).
+    'Hello, World!', # The expected result to compare with 'hello'.
+    'Say Hi!'        # The test description.
 );

--- a/exercises/practice/leap/.meta/exercise-data.yaml
+++ b/exercises/practice/leap/.meta/exercise-data.yaml
@@ -9,8 +9,9 @@ properties:
   leapYear:
     test: |-
       sprintf(q:to/END/, %case<input><year>, %case<expected>, %case<description>);
-      is-deeply(
+      cmp-ok(
           is-leap-year(%s),
+          "eqv",
           %s,
           '%s',
       );

--- a/exercises/practice/leap/leap.rakutest
+++ b/exercises/practice/leap/leap.rakutest
@@ -10,56 +10,65 @@ for Date, DateTime {
     };
 }
 
-is-deeply(
+cmp-ok(
     is-leap-year(2015),
+    "eqv",
     False,
     'year not divisible by 4 in common year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(1970),
+    "eqv",
     False,
     'year divisible by 2, not divisible by 4 in common year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(1996),
+    "eqv",
     True,
     'year divisible by 4, not divisible by 100 in leap year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(1960),
+    "eqv",
     True,
     'year divisible by 4 and 5 is still a leap year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(2100),
+    "eqv",
     False,
     'year divisible by 100, not divisible by 400 in common year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(1900),
+    "eqv",
     False,
     'year divisible by 100 but not by 3 is still not a leap year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(2000),
+    "eqv",
     True,
     'year divisible by 400 is leap year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(2400),
+    "eqv",
     True,
     'year divisible by 400 but not by 125 is still a leap year',
 );
 
-is-deeply(
+cmp-ok(
     is-leap-year(1800),
+    "eqv",
     False,
     'year divisible by 200, not divisible by 400 in common year',
 );

--- a/exercises/practice/phone-number/.meta/exercise-data.yaml
+++ b/exercises/practice/phone-number/.meta/exercise-data.yaml
@@ -14,8 +14,9 @@ properties:
       }
       else {
           sprintf(q:to/END/, (%case<input><phrase>, |%case<expected description>).map(*.raku));
-          is(
+          cmp-ok(
               clean-number(%s),
+              "eq",
               %s,
               %s,
           );

--- a/exercises/practice/phone-number/phone-number.rakutest
+++ b/exercises/practice/phone-number/phone-number.rakutest
@@ -3,20 +3,23 @@ use Test;
 use lib $?FILE.IO.dirname;
 use Phone;
 
-is(
+cmp-ok(
     clean-number("(223) 456-7890"),
+    "eq",
     "2234567890",
     "cleans the number",
 );
 
-is(
+cmp-ok(
     clean-number("223.456.7890"),
+    "eq",
     "2234567890",
     "cleans numbers with dots",
 );
 
-is(
+cmp-ok(
     clean-number("223 456   7890   "),
+    "eq",
     "2234567890",
     "cleans numbers with multiple spaces",
 );
@@ -35,14 +38,16 @@ throws-like(
     "invalid when 11 digits does not start with a 1",
 );
 
-is(
+cmp-ok(
     clean-number("12234567890"),
+    "eq",
     "2234567890",
     "valid when 11 digits and starting with 1",
 );
 
-is(
+cmp-ok(
     clean-number("+1 (223) 456-7890"),
+    "eq",
     "2234567890",
     "valid when 11 digits and starting with 1 even with punctuation",
 );

--- a/exercises/practice/raindrops/.meta/exercise-data.yaml
+++ b/exercises/practice/raindrops/.meta/exercise-data.yaml
@@ -2,13 +2,13 @@ properties:
   convert:
     test: |-
       sprintf(q:to/END/, (%case<input><number>, |%case<expected description>).map(*.raku));
-      is-deeply(
+      cmp-ok(
           raindrop(%s),
+          "eqv",
           %s,
           %s,
       );
       END
-
 
 unit: module
 example: |-

--- a/exercises/practice/raindrops/raindrops.rakutest
+++ b/exercises/practice/raindrops/raindrops.rakutest
@@ -3,110 +3,128 @@ use Test;
 use lib $?FILE.IO.dirname;
 use Raindrops;
 
-is-deeply(
+cmp-ok(
     raindrop(1),
+    "eqv",
     "1",
     "the sound for 1 is 1",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(3),
+    "eqv",
     "Pling",
     "the sound for 3 is Pling",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(5),
+    "eqv",
     "Plang",
     "the sound for 5 is Plang",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(7),
+    "eqv",
     "Plong",
     "the sound for 7 is Plong",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(6),
+    "eqv",
     "Pling",
     "the sound for 6 is Pling as it has a factor 3",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(8),
+    "eqv",
     "8",
     "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(9),
+    "eqv",
     "Pling",
     "the sound for 9 is Pling as it has a factor 3",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(10),
+    "eqv",
     "Plang",
     "the sound for 10 is Plang as it has a factor 5",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(14),
+    "eqv",
     "Plong",
     "the sound for 14 is Plong as it has a factor of 7",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(15),
+    "eqv",
     "PlingPlang",
     "the sound for 15 is PlingPlang as it has factors 3 and 5",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(21),
+    "eqv",
     "PlingPlong",
     "the sound for 21 is PlingPlong as it has factors 3 and 7",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(25),
+    "eqv",
     "Plang",
     "the sound for 25 is Plang as it has a factor 5",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(27),
+    "eqv",
     "Pling",
     "the sound for 27 is Pling as it has a factor 3",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(35),
+    "eqv",
     "PlangPlong",
     "the sound for 35 is PlangPlong as it has factors 5 and 7",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(49),
+    "eqv",
     "Plong",
     "the sound for 49 is Plong as it has a factor 7",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(52),
+    "eqv",
     "52",
     "the sound for 52 is 52",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(105),
+    "eqv",
     "PlingPlangPlong",
     "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7",
 );
 
-is-deeply(
+cmp-ok(
     raindrop(3125),
+    "eqv",
     "Plang",
     "the sound for 3125 is Plang as it has a factor 5",
 );

--- a/exercises/practice/roman-numerals/.meta/exercise-data.yaml
+++ b/exercises/practice/roman-numerals/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   roman:
     test: |-
       sprintf(q:to/END/, (%case<input><number>, |%case<expected description>).map(*.raku));
-      is(
+      cmp-ok(
           to-roman(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/roman-numerals/roman-numerals.rakutest
+++ b/exercises/practice/roman-numerals/roman-numerals.rakutest
@@ -3,146 +3,170 @@ use Test;
 use lib $?FILE.IO.dirname;
 use RomanNumerals;
 
-is(
+cmp-ok(
     to-roman(1),
+    "eq",
     "I",
     "1 is I",
 );
 
-is(
+cmp-ok(
     to-roman(2),
+    "eq",
     "II",
     "2 is II",
 );
 
-is(
+cmp-ok(
     to-roman(3),
+    "eq",
     "III",
     "3 is III",
 );
 
-is(
+cmp-ok(
     to-roman(4),
+    "eq",
     "IV",
     "4 is IV",
 );
 
-is(
+cmp-ok(
     to-roman(5),
+    "eq",
     "V",
     "5 is V",
 );
 
-is(
+cmp-ok(
     to-roman(6),
+    "eq",
     "VI",
     "6 is VI",
 );
 
-is(
+cmp-ok(
     to-roman(9),
+    "eq",
     "IX",
     "9 is IX",
 );
 
-is(
+cmp-ok(
     to-roman(27),
+    "eq",
     "XXVII",
     "27 is XXVII",
 );
 
-is(
+cmp-ok(
     to-roman(48),
+    "eq",
     "XLVIII",
     "48 is XLVIII",
 );
 
-is(
+cmp-ok(
     to-roman(49),
+    "eq",
     "XLIX",
     "49 is XLIX",
 );
 
-is(
+cmp-ok(
     to-roman(59),
+    "eq",
     "LIX",
     "59 is LIX",
 );
 
-is(
+cmp-ok(
     to-roman(93),
+    "eq",
     "XCIII",
     "93 is XCIII",
 );
 
-is(
+cmp-ok(
     to-roman(141),
+    "eq",
     "CXLI",
     "141 is CXLI",
 );
 
-is(
+cmp-ok(
     to-roman(163),
+    "eq",
     "CLXIII",
     "163 is CLXIII",
 );
 
-is(
+cmp-ok(
     to-roman(402),
+    "eq",
     "CDII",
     "402 is CDII",
 );
 
-is(
+cmp-ok(
     to-roman(575),
+    "eq",
     "DLXXV",
     "575 is DLXXV",
 );
 
-is(
+cmp-ok(
     to-roman(911),
+    "eq",
     "CMXI",
     "911 is CMXI",
 );
 
-is(
+cmp-ok(
     to-roman(1024),
+    "eq",
     "MXXIV",
     "1024 is MXXIV",
 );
 
-is(
+cmp-ok(
     to-roman(3000),
+    "eq",
     "MMM",
     "3000 is MMM",
 );
 
-is(
+cmp-ok(
     to-roman(16),
+    "eq",
     "XVI",
     "16 is XVI",
 );
 
-is(
+cmp-ok(
     to-roman(66),
+    "eq",
     "LXVI",
     "66 is LXVI",
 );
 
-is(
+cmp-ok(
     to-roman(166),
+    "eq",
     "CLXVI",
     "166 is CLXVI",
 );
 
-is(
+cmp-ok(
     to-roman(666),
+    "eq",
     "DCLXVI",
     "666 is DCLXVI",
 );
 
-is(
+cmp-ok(
     to-roman(1666),
+    "eq",
     "MDCLXVI",
     "1666 is MDCLXVI",
 );

--- a/exercises/practice/two-fer/.meta/exercise-data.yaml
+++ b/exercises/practice/two-fer/.meta/exercise-data.yaml
@@ -2,8 +2,9 @@ properties:
   twoFer:
     test: |-
       sprintf(q:to/END/, (with %case<input><name> { .raku } else { '' }), |%case<expected description>.map(*.raku));
-      is(
+      cmp-ok(
           two-fer(%s),
+          "eq",
           %s,
           %s,
       );

--- a/exercises/practice/two-fer/two-fer.rakutest
+++ b/exercises/practice/two-fer/two-fer.rakutest
@@ -3,20 +3,23 @@ use Test;
 use lib $?FILE.IO.dirname; #`[Look for the module inside the same directory as this test file.]
 use TwoFer;
 
-is(
+cmp-ok(
     two-fer(),
+    "eq",
     "One for you, one for me.",
     "no name given",
 );
 
-is(
+cmp-ok(
     two-fer("Alice"),
+    "eq",
     "One for Alice, one for me.",
     "a name given",
 );
 
-is(
+cmp-ok(
     two-fer("Bob"),
+    "eq",
     "One for Bob, one for me.",
     "another name given",
 );


### PR DESCRIPTION
`cmp-ok` lets you explicitly specify how given values are being compared. `is` and `is-deeply` are less obvious in comparison and also have alternate behaviours which are not immediately apparent.