### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -157,7 +157,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "378da8ed-c955-4a27-87b4-078b36479d77",
         "practices": [],
         "prerequisites": [],
@@ -193,7 +193,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "3bee4dc2-d747-4b4e-ac10-d7815666bbc0",
         "practices": [],
         "prerequisites": [],
@@ -375,7 +375,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "8173b8cb-e2a7-4ecf-9ee8-868db1c06b0c",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579