### PR TITLE
Remove large number tests from perfect-numbers

### DIFF
--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -17,6 +17,8 @@ description = "Perfect numbers -> Medium perfect number is classified correctly"
 
 [ee3627c4-7b36-4245-ba7c-8727d585f402]
 description = "Perfect numbers -> Large perfect number is classified correctly"
+include = false
+comment = "too slow for basic implementations"
 
 [80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
 description = "Abundant numbers -> Smallest abundant number is classified correctly"
@@ -26,6 +28,8 @@ description = "Abundant numbers -> Medium abundant number is classified correctl
 
 [ec7792e6-8786-449c-b005-ce6dd89a772b]
 description = "Abundant numbers -> Large abundant number is classified correctly"
+include = false
+comment = "too slow for basic implementations"
 
 [e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
 description = "Deficient numbers -> Smallest prime deficient number is classified correctly"
@@ -38,6 +42,8 @@ description = "Deficient numbers -> Medium deficient number is classified correc
 
 [47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
 description = "Deficient numbers -> Large deficient number is classified correctly"
+include = false
+comment = "too slow for basic implementations"
 
 [a696dec8-6147-4d68-afad-d38de5476a56]
 description = "Deficient numbers -> Edge case (no factors other than itself) is classified correctly"

--- a/exercises/practice/perfect-numbers/perfect-numbers.rakutest
+++ b/exercises/practice/perfect-numbers/perfect-numbers.rakutest
@@ -17,13 +17,6 @@ cmp-ok( # begin: 169a7854-0431-4ae0-9815-c3b6d967436d
     "Perfect numbers: Medium perfect number is classified correctly",
 ); # end: 169a7854-0431-4ae0-9815-c3b6d967436d
 
-cmp-ok( # begin: ee3627c4-7b36-4245-ba7c-8727d585f402
-    aliquot-sum-type(33550336),
-    "eqv",
-    Perfect,
-    "Perfect numbers: Large perfect number is classified correctly",
-); # end: ee3627c4-7b36-4245-ba7c-8727d585f402
-
 cmp-ok( # begin: 80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e
     aliquot-sum-type(12),
     "eqv",
@@ -37,13 +30,6 @@ cmp-ok( # begin: 3e300e0d-1a12-4f11-8c48-d1027165ab60
     Abundant,
     "Abundant numbers: Medium abundant number is classified correctly",
 ); # end: 3e300e0d-1a12-4f11-8c48-d1027165ab60
-
-cmp-ok( # begin: ec7792e6-8786-449c-b005-ce6dd89a772b
-    aliquot-sum-type(33550335),
-    "eqv",
-    Abundant,
-    "Abundant numbers: Large abundant number is classified correctly",
-); # end: ec7792e6-8786-449c-b005-ce6dd89a772b
 
 cmp-ok( # begin: e610fdc7-2b6e-43c3-a51c-b70fb37413ba
     aliquot-sum-type(2),
@@ -65,13 +51,6 @@ cmp-ok( # begin: 1c802e45-b4c6-4962-93d7-1cad245821ef
     Deficient,
     "Deficient numbers: Medium deficient number is classified correctly",
 ); # end: 1c802e45-b4c6-4962-93d7-1cad245821ef
-
-cmp-ok( # begin: 47dd569f-9e5a-4a11-9a47-a4e91c8c28aa
-    aliquot-sum-type(33550337),
-    "eqv",
-    Deficient,
-    "Deficient numbers: Large deficient number is classified correctly",
-); # end: 47dd569f-9e5a-4a11-9a47-a4e91c8c28aa
 
 cmp-ok( # begin: a696dec8-6147-4d68-afad-d38de5476a56
     aliquot-sum-type(1),


### PR DESCRIPTION
A basic check for factors performs slowly to the point of timing out in the online test runner:

```raku
(1..($n div 2)).race.grep($n %% *).sum <=> $n
```

Optimization is nice but I don't believe a lack of it from a student should be blocking.