### PR TITLE
Disable concept exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "slug": "raku",
   "active": true,
   "status": {
-    "concept_exercises": true,
+    "concept_exercises": false,
     "test_runner": true,
     "representer": false,
     "analyzer": false


### PR DESCRIPTION
The `config.json` change should not have enabled as the concept exercises are not launched.