### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/exercises.yml
+++ b/.github/workflows/exercises.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rakudo Star on ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Rakudo Star with choco
         if: runner.os == 'Windows'

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - run: bin/fetch-configlet
       - run: bin/configlet sync || true


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.