### PR TITLE
Automatically flunk tests omitted from generator

### DIFF
--- a/bin/exercise-gen.raku
+++ b/bin/exercise-gen.raku
@@ -1,6 +1,5 @@
 #!/usr/bin/env raku
 use YAMLish;
-use nqp;
 use lib ( my $base-dir = $?FILE.IO.resolve.parent(2) ).add('lib');
 use Exercism::Generator;
 
@@ -16,12 +15,12 @@ multi MAIN ( Bool:D :h(:help(:$man)) ) {
 
 #| Runs the generator for everything in the exercises/practice directory.
 multi MAIN (Bool:D :a(:$all) where *.so) {
-  generate .basename for $base-dir.add('exercises/practice').dir;
+  samewith $base-dir.add('exercises/practice').dir.map(*.basename).sort;
 }
 
 #| The generator will run for each exercise given as an argument.
 multi MAIN (*@exercises) {
-  @exercises».&generate;
+  .&generate for @exercises;
 }
 
 #|[The generator will attempt to run using the current directory.
@@ -47,22 +46,24 @@ sub generate ($exercise) {
       note '.meta/template-data.yaml not found for: ' ~ join ' ', @yaml-not-found
     }
   }
-  if (
+
+  when (
     my $exercise-dir = $base-dir.add("exercises/practice/$exercise")
   ) !~~ :d {
     push @dir-not-found, $exercise;
-    return;
   }
-  if (
+
+  when (
     my $yaml-file = $exercise-dir.add('.meta/template-data.yaml')
   ) !~~ :f {
     push @yaml-not-found, $exercise;
-    return;
   }
 
-  print "Generating $exercise... ";
+  default {
+    print "Generating $exercise... ";
 
-  Exercism::Generator.new(:$exercise).create-files;
+    Exercism::Generator.new(:$exercise).create-files;
 
-  say 'Generated.';
+    say 'Generated.';
+  }
 }

--- a/exercises/practice/binary-search-tree/.meta/tests.toml
+++ b/exercises/practice/binary-search-tree/.meta/tests.toml
@@ -11,18 +11,23 @@
 
 [e9c93a78-c536-4750-a336-94583d23fafa]
 description = "data is retained"
+include = false
 
 [7a95c9e8-69f6-476a-b0c4-4170cb3f7c91]
 description = "insert data at proper node -> smaller number at left node"
+include = false
 
 [22b89499-9805-4703-a159-1a6e434c1585]
 description = "insert data at proper node -> same number at left node"
+include = false
 
 [2e85fdde-77b1-41ed-b6ac-26ce6b663e34]
 description = "insert data at proper node -> greater number at right node"
+include = false
 
 [dd898658-40ab-41d0-965e-7f145bf66e0b]
 description = "can create complex tree"
+include = false
 
 [9e0c06ef-aeca-4202-b8e4-97f1ed057d56]
 description = "can sort data -> can sort single number"

--- a/lib/Exercism/Generator.rakumod
+++ b/lib/Exercism/Generator.rakumod
@@ -33,16 +33,7 @@ has %.cdata = do if ( my $cdata-file = $ProblemSpecsDir.add("exercises/$!exercis
 has Str:D @.case-uuids = do if (
   my $toml-file = $base-dir.add("exercises/practice/$!exercise/.meta/tests.toml")
 ).f {
-  given from-toml($toml-file.slurp) {
-    # TODO: Remove old toml format
-    when .<canonical-tests>:exists {
-      .<canonical-tests>.Set.keys;
-    }
-
-    default {
-      .grep({ .value.<include>:!exists || .value.<include> }).map(*.key);
-    }
-  }
+  from-toml($toml-file.slurp).grep({ .value.<include>:!exists || .value.<include> }).map(*.key);
 } #= e.g. [ '00000000-0000-0000-0000-000000000000' ]
 ;
 
@@ -65,7 +56,7 @@ submethod build-cases ( %obj, Str $description = '' ) {
     }
 
     return %obj<cases>.map({
-      self.&?ROUTINE( $_, $new-desc || $description )
+      self.&samewith( $_, $new-desc || $description )
     }).flat;
   }
   elsif %obj<uuid> ∈ @!case-uuids {
@@ -88,6 +79,9 @@ submethod build-property-tests {
         @output[0] ~= " # begin: %case<uuid>\n";
       }
       @tests.push(@output.join.trim-trailing ~ ' # ' ~ (@output > 1 ?? 'end' !! 'case') ~ ": %case<uuid>\n");
+    }
+    else {
+      @tests.push("flunk; # case: %case<uuid>\n")
     }
   }
   return @tests;


### PR DESCRIPTION
This is to ensure that tests included in the toml file are not accidentally missed.