### PR TITLE
Add leap error test

### DIFF
--- a/exercises/practice/leap/.meta/solutions/forbidden/leap.rakutest
+++ b/exercises/practice/leap/.meta/solutions/forbidden/leap.rakutest
@@ -1,1 +1,0 @@
-../../../../t/leap.rakutest

--- a/exercises/practice/leap/.meta/solutions/forbidden/t/leap.rakutest
+++ b/exercises/practice/leap/.meta/solutions/forbidden/t/leap.rakutest
@@ -1,0 +1,14 @@
+#!/usr/bin/env raku
+use Test;
+use lib $?FILE.IO.parent(2).add('lib');
+use Leap;
+
+for Date, DateTime {
+    .^method_table<new>.wrap: sub (|) {
+        pass 'Creating a Date(Time) object is not allowed for this exercise.';
+    };
+}
+
+is-leap-year(2015);
+
+done-testing;

--- a/lib/Exercism/Generator.rakumod
+++ b/lib/Exercism/Generator.rakumod
@@ -179,7 +179,7 @@ method create-files ( --> Nil ) {
       # This emulates Raku's symlink, which does not yet support non-absolute paths
       try nqp::symlink(
         "../../../../t/$_",
-        nqp::unbox_s( $solution-dir.add($_).absolute )
+        nqp::unbox_s( $solution-dir.add('t', $_).absolute )
       ) given $testfile.basename;
     }
   }


### PR DESCRIPTION
The leap exercise had a custom test to check if a Date(Time) object creation is attempted, and this looks to have gone missing. Restoring it.